### PR TITLE
Add URIs for some dataset targets

### DIFF
--- a/data/ClinTox/meta.yaml
+++ b/data/ClinTox/meta.yaml
@@ -12,6 +12,9 @@ targets:
           - toxicity
           - drug Induced clinical toxicity
           - drug failed in clinical trials
+      uris:
+          - http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C27990
+          - http://purl.bioontology.org/ontology/MESH/Q000633
 identifiers:
     - id: SMILES
       type: SMILES

--- a/data/caco2_wang/meta.yaml
+++ b/data/caco2_wang/meta.yaml
@@ -14,6 +14,8 @@ targets:
           - Caco-2 cell permeability
           - Caco-2 permeability
           - permeability
+      uris:
+          - http://www.bioassayontology.org/bao#BAO_0002808
 identifiers:
     - id: SMILES
       type: SMILES

--- a/data/flashpoint/meta.yaml
+++ b/data/flashpoint/meta.yaml
@@ -14,6 +14,8 @@ targets:
       type: continuous
       names:
           - flash point
+      uris:
+          - https://doi.org/10.1351/goldbook.F02419
 identifiers:
     - id: smiles
       type: SMILES

--- a/data/freesolv/meta.yaml
+++ b/data/freesolv/meta.yaml
@@ -8,6 +8,8 @@ targets:
       type: continuous
       names:
           - hydration free energy
+      uris:
+          - https://doi.org/10.1351/goldbook.F02515
     - id: exp_uncertainty
       description: experimental hydration free energy uncertainty
       units: kcal/mol

--- a/data/ld50_zhu/meta.yaml
+++ b/data/ld50_zhu/meta.yaml
@@ -13,6 +13,10 @@ targets:
           - conservative dose that can lead to lethal adverse effects.
           - Rat Acute Toxicity by Oral Exposure
           - Toxicity
+      uris:
+          - http://www.bioassayontology.org/bao#BAO_0002117
+          - http://sbmi.uth.tmc.edu/ontology/ochv#C0023378
+
 identifiers:
     - id: SMILES
       type: SMILES

--- a/data/lipophilicity/meta.yaml
+++ b/data/lipophilicity/meta.yaml
@@ -9,6 +9,8 @@ targets:
       names:
           - octanol/water distribution coefficient (logD at pH 7.4)
           - octanol/water distribution coefficient
+      uris:
+          - http://www.bioassayontology.org/bao#BAO_0010241
 identifiers:
     - id: SMILES
       type: SMILES

--- a/data/pampa_ncats/meta.yaml
+++ b/data/pampa_ncats/meta.yaml
@@ -16,6 +16,8 @@ targets:
           - binary permeability in PAMPA assay
           - permeability in PAMPA assay
           - PAMPA permeability
+      uris:
+          - http://www.bioassayontology.org/bao#BAO_0010072
 identifiers:
     - id: SMILES
       type: SMILES

--- a/dev/model.py
+++ b/dev/model.py
@@ -23,6 +23,13 @@ class Identifier(YamlModel):
     type: IdentifierEnum
     names: Optional[List[str]]
 
+    """A URI or multiple (consitent ) URIs for the field. 
+
+    Ideally this would be a link to an entry in an ontrology or controlled 
+    vocabulary that can also provide a canonical description for the field.
+    """
+    uri: Optional[List[str]]
+
     @root_validator
     def if_optional_has_names(cls, values):
         if (values.get("names") is None) and (

--- a/dev/model.py
+++ b/dev/model.py
@@ -23,9 +23,9 @@ class Identifier(YamlModel):
     type: IdentifierEnum
     names: Optional[List[str]]
 
-    """A URI or multiple (consitent ) URIs for the field. 
+    """A URI or multiple (consitent ) URIs for the field.
 
-    Ideally this would be a link to an entry in an ontrology or controlled 
+    Ideally this would be a link to an entry in an ontrology or controlled
     vocabulary that can also provide a canonical description for the field.
     """
     uri: Optional[List[str]]


### PR DESCRIPTION
This PR quickly mocks up the addition of URIs to dataset target metadata. Somewhat addresses #8 --- need to decide how useful this is first.

The idea is that these URIs can at least i) resolve whether two definitions are the same across datasets and could potentially ii) be used to augment the dataset with canonical descriptions and semantic links, either during prep or by the model on-the-fly.

This currently assumes an "exact match" style mapping between target and property -- we could build in additional semantic context in the schema here to enable things like related identities/subclasses/parthood and all that jazz. I struggled with the `Butkiewicz` sets as it is really outside my field and definitions are available for e.g., `cav3`, `t-type`, `calcium channel` and `activity` but not `activity_cav3_t_type_calcium_channels`.

As discussed, this is quite a niche task that may not be suitable to ask others to perform. Even in my own case, it is not clear exactly how good these particular definitions are -- I just went via BioPortal for fields that have good matches: https://bioportal.bioontology.org/ 

