### PR TITLE
fix: add `main` branch for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "gpt-neox"]
 	path = gpt-neox
 	url = git@github.com:EleutherAI/gpt-neox.git
+	branch = main


### PR DESCRIPTION
When developing on the stability cluster a recursive cloning of all submodules failed due to the script looking for a `origin/master` revision of `gpt-neox`.

This change just updates the branch naming convention to be `main`.