### PR TITLE
Fix: update environment scripts for submodules

### DIFF
--- a/experiments/scripts/env_creation_hf.sh
+++ b/experiments/scripts/env_creation_hf.sh
@@ -22,7 +22,7 @@ conda activate ${CONDA_ENV_PATH}
 cd /fsx/proj-chemnlp/$2
 
 ## clone + submodules (ok if exists)
-[ ! -d 'chemnlp' ] && git clone --recurse-submodules --remote-submodules git@github.com:OpenBioML/chemnlp.git
+[ ! -d 'chemnlp' ] && git clone --recurse-submodules git@github.com:OpenBioML/chemnlp.git
 
 ## install core requirements
 conda install -y pytorch torchvision torchaudio pytorch-cuda=${CUDA_VERSION} -c pytorch -c nvidia --verbose

--- a/experiments/scripts/env_creation_neox.sh
+++ b/experiments/scripts/env_creation_neox.sh
@@ -21,7 +21,7 @@ conda activate ${CONDA_ENV_PATH}
 cd /fsx/proj-chemnlp/$2
 
 ## clone + submodules (ok if exists)
-[ ! -d 'chemnlp' ] && git clone --recurse-submodules --remote-submodules git@github.com:OpenBioML/chemnlp.git
+[ ! -d 'chemnlp' ] && git clone --recurse-submodules git@github.com:OpenBioML/chemnlp.git
 
 ## install
 cd chemnlp/gpt-neox


### PR DESCRIPTION
Remove unneeded `--remote-submodules` argument. This will update the submodules to follow the latest commit on the remote, which might not be the SHA-1 we are tracking in `chemnlp` (i.e. if someone has updated the submodule remotely but we haven't switched to using it yet in `chemnlp`).

See [here](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---no-remote-submodules) for reference.