### PR TITLE
feat: add features for fine-tuning

### DIFF
--- a/docs/EXPERIMENT.md
+++ b/docs/EXPERIMENT.md
@@ -2,6 +2,7 @@
 Here we describe the set-up for training a model (including on the Stability cluster).
 
 ## General set-up
+- Configs are in: `experiments/configs`.
 -  If you wish to use a new model from Hugging Face as the starting point you will need to tokenise your data. We have an example script for `chemrxiv` which does this here: `experiments/data/prepare_hf_chemrxiv.py`.
 -  You will also need to create a configuration file for the model if one does not exist e.g. `experiments/configs/hugging-face/full_160M.yml`.
 
@@ -27,3 +28,20 @@ sbatch experiments/scripts/sbatch_train_hf.sh experiments/maw501 maw501 160M_ful
 
 ## Using Weights and Biases
 If you don't have the required permission to log to W&B, please request this. In the interim you can disable this or log to a project under your name by changing the configuration options e.g. in `experiments/configs/hugging-face/full_160M.yml`.
+
+## Restarting from a checkpoint
+This is for Hugging Face fine-tuning only at the moment.
+
+**WARNING:** Hugging Face **does not** know you are restarting from a checkpoint and so you may wish to change `output_dir` in the config file to avoid overwriting old checkpoints. You may wish to use a lower learning rate / different scheduler if continuing training.
+
+You can restart training from a checkpoint by passing `checkpoint_path`, a directory containing the output from a model saved by HF's `Trainer` class.
+
+Example config block:
+
+```yaml
+model:
+  base: GPTNeoXForCausalLM
+  name: EleutherAI/pythia-160m
+  revision: main
+  checkpoint_path: /fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_160M/checkpoint-1600  # directory to restart training from
+```

--- a/docs/EXPERIMENT.md
+++ b/docs/EXPERIMENT.md
@@ -1,0 +1,29 @@
+# Running an experiment
+Here we describe the set-up for training a model (including on the Stability cluster).
+
+## General set-up
+-  If you wish to use a new model from Hugging Face as the starting point you will need to tokenise your data. We have an example script for `chemrxiv` which does this here: `experiments/data/prepare_hf_chemrxiv.py`.
+-  You will also need to create a configuration file for the model if one does not exist e.g. `experiments/configs/hugging-face/full_160M.yml`.
+
+If the data is already tokenised for the model you wish to use you can proceed to the next step.
+
+## Interactive run
+-  Create a conda environment as shown in [the documentation](https://github.com/OpenBioML/chemnlp/tree/main/experiments/scripts) and install `chemnlp`.
+- If using Weights and Biases for logging: `export WANDB_BASE_URL="https://stability.wandb.io"`.
+- Run using `torchrun`, for example:
+    ```
+    torchrun --nnodes 1 --nproc-per-node 4 experiments/scripts/run_tune.py experiments/configs/hugging-face/full_160M.yml
+    ```
+- You can use `nvidia-smi` or `wandb` logging to monitor efficiency during this step.
+
+## Launching an experiment run through SLURM
+- Take the `sbatch_<suffix>` script associated with the training run and execute this through an `sbatch` command as shown in [the documentation](https://github.com/OpenBioML/chemnlp/tree/main/experiments). This will build the conda environment and install `chemnlp` before the job begins. Note that building the environment can be a little slow so if you aren't confident your code will run it's best to test it interactively first.
+- Example command:
+
+```bash
+sbatch experiments/scripts/sbatch_train_hf.sh experiments/maw501 maw501 160M_full.yml
+```
+- Locally you can monitor your job at `/fsx/proj-chemnlp/experiments/logs` or as set in the `sbatch` script.
+
+## Using Weights and Biases
+If you don't have the required permission to log to W&B, please request this. In the interim you can disable this or log to a project under your name by changing the configuration options e.g. in `experiments/configs/hugging-face/full_160M.yml`.

--- a/docs/EXPERIMENT.md
+++ b/docs/EXPERIMENT.md
@@ -22,9 +22,10 @@ If the data is already tokenised for the model you wish to use you can proceed t
 - Example command:
 
 ```bash
-sbatch experiments/scripts/sbatch_train_hf.sh experiments/maw501 maw501 160M_full.yml
+sbatch experiments/scripts/sbatch_train_hf.sh $1 $2 $3  # see script for description of arguments
+sbatch experiments/scripts/sbatch_train_hf.sh experiments/maw501 maw501 160M_full.yml  # explicit example
 ```
-- Locally you can monitor your job at `/fsx/proj-chemnlp/experiments/logs` or as set in the `sbatch` script.
+- From within the stability cluster, you can monitor your job at `/fsx/proj-chemnlp/experiments/logs` or as set in the `sbatch` script.
 
 ## Using Weights and Biases
 If you don't have the required permission to log to W&B, please request this. In the interim you can disable this or log to a project under your name by changing the configuration options e.g. in `experiments/configs/hugging-face/full_160M.yml`.

--- a/experiments/configs/hugging-face/160M_full.yml
+++ b/experiments/configs/hugging-face/160M_full.yml
@@ -17,7 +17,7 @@ prompt_tuning:
 # Training configuration (TrainerArguments from HF)
 trainer:
   output_dir: /fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_160M
-  num_train_epochs: 0.1
+  num_train_epochs: 1
   learning_rate: 3e-4
   evaluation_strategy: steps
   logging_steps: 5

--- a/experiments/configs/hugging-face/160M_full.yml
+++ b/experiments/configs/hugging-face/160M_full.yml
@@ -8,6 +8,7 @@ model:
   base: GPTNeoXForCausalLM
   name: EleutherAI/pythia-160m
   revision: main # latest model
+  #checkpoint_path: /fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_160M/checkpoint-1600
 
 # Training strategies (PromptTuningConfig arguments)
 prompt_tuning:
@@ -16,7 +17,7 @@ prompt_tuning:
 # Training configuration (TrainerArguments from HF)
 trainer:
   output_dir: /fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_160M
-  num_train_epochs: 1
+  num_train_epochs: 1.0
   learning_rate: 3e-4
   evaluation_strategy: steps
   logging_steps: 5

--- a/experiments/configs/hugging-face/160M_full.yml
+++ b/experiments/configs/hugging-face/160M_full.yml
@@ -17,7 +17,7 @@ prompt_tuning:
 # Training configuration (TrainerArguments from HF)
 trainer:
   output_dir: /fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_160M
-  num_train_epochs: 1.0
+  num_train_epochs: 0.1
   learning_rate: 3e-4
   evaluation_strategy: steps
   logging_steps: 5
@@ -35,3 +35,4 @@ wandb:
   project: LLCheM
   group: test
   name: test_160M_full # full_160M_v1
+  entity: chemnlp

--- a/experiments/configs/hugging-face/1B_fine_tune.yml
+++ b/experiments/configs/hugging-face/1B_fine_tune.yml
@@ -1,12 +1,12 @@
 ---
 # Dataset configuration (datasets.load_from_disk arguments)
 data:
-  path: /fsx/proj-chemnlp/data/EleutherAI/pythia-160m/marianna13/chemrxiv
+  path: /fsx/proj-chemnlp/data/EleutherAI/pythia-1b/marianna13/chemrxiv
 
 # Model configuration (model.from_pretrained arguments)
 model:
   base: GPTNeoXForCausalLM
-  name: EleutherAI/pythia-160m
+  name: EleutherAI/pythia-1b
   revision: main # latest model
 
 # Training strategies (PromptTuningConfig arguments)
@@ -15,22 +15,22 @@ prompt_tuning:
 
 # Training configuration (TrainerArguments from HF)
 trainer:
-  output_dir: /fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_160M
+  output_dir: /fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_1b
   num_train_epochs: 1
   learning_rate: 3e-4
   evaluation_strategy: steps
-  logging_steps: 5
-  eval_steps: 50
-  save_steps: 200
+  logging_steps: 50
+  eval_steps: 500
+  save_steps: 1000
   dataloader_num_workers: 4
   bf16: true
   fp16: false
-  per_device_train_batch_size: 28
-  per_device_eval_batch_size: 28
+  per_device_train_batch_size: 2
+  per_device_eval_batch_size: 8
 
 # Logging configuration (WandB init arguments)
 wandb:
   enabled: true
   project: LLCheM
   group: test
-  name: test_160M_full # full_160M_v1
+  name: test_1b_fine_tune

--- a/experiments/scripts/run_tune.py
+++ b/experiments/scripts/run_tune.py
@@ -76,6 +76,7 @@ def run(config_path: str) -> None:
     )
     assert trainer.model.device.type != "cpu", "Stopping as model is on CPU"
     trainer.train()
+    trainer.save_model()
 
 
 if __name__ == "__main__":

--- a/experiments/scripts/run_tune.py
+++ b/experiments/scripts/run_tune.py
@@ -8,6 +8,7 @@ import os
 
 import datasets
 import transformers
+import wandb
 from peft import PromptTuningConfig, PromptTuningInit, TaskType, get_peft_model
 from transformers import (
     AutoTokenizer,
@@ -16,7 +17,6 @@ from transformers import (
     TrainingArguments,
 )
 
-import wandb
 from chemnlp.data_val.config import TrainPipelineConfig
 from chemnlp.utils import load_config
 

--- a/experiments/scripts/sbatch_train_hf.sh
+++ b/experiments/scripts/sbatch_train_hf.sh
@@ -19,6 +19,7 @@
 
 set -ex # allow for exiting based on non-0 codes
 export TOKENIZERS_PARALLELISM=false
+export WANDB_BASE_URL="https://stability.wandb.io"
 
 # set workdir
 CHEMNLP_PATH=/fsx/proj-chemnlp/$2/chemnlp
@@ -28,7 +29,7 @@ source $CHEMNLP_PATH/experiments/scripts/env_creation_hf.sh $1 $2
 
 # install extras
 cd $CHEMNLP_PATH
-pip install ".[training]"
+pip install .
 
 # trigger run
 torchrun --nnodes 1 --nproc-per-node 4 \

--- a/experiments/working/calculate_nll.py
+++ b/experiments/working/calculate_nll.py
@@ -1,0 +1,61 @@
+import torch
+from datasets import load_dataset
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# See: https://huggingface.co/docs/transformers/perplexity
+
+MAX_LENGTH = 2048
+STRIDE = 512
+BASE_STRING = "EleutherAI/pythia-"
+PYTHIA_MODELS = ["70m", "160m", "410m", "1b", "1.4b", "2.8b"]
+MODELS = [BASE_STRING + x for x in PYTHIA_MODELS]
+print(f"Running models: {MODELS}")
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+dataset = load_dataset("aeslc")["test"]
+print(f"Loaded dataset, size: {len(dataset)}")
+
+results = {k: None for k in MODELS}
+
+for model_name in MODELS:
+    print(f"Starting model: {model_name}")
+    model = AutoModelForCausalLM.from_pretrained(model_name).to(DEVICE)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    # Join dataset into one long document:
+    tokenized_dataset = tokenizer(
+        "\n\n".join(dataset["email_body"]), return_tensors="pt"
+    )
+    seq_len = tokenized_dataset.input_ids.size(1)
+    prev_end_loc = 0
+    nlls = []
+
+    for begin_loc in tqdm(range(0, seq_len, STRIDE)):
+        end_loc = min(begin_loc + MAX_LENGTH, seq_len)
+        trg_len = end_loc - prev_end_loc  # may be different from stride on last loop
+
+        # Get data:
+        input_ids = tokenized_dataset.input_ids[:, begin_loc:end_loc].to(DEVICE)
+        target_ids = input_ids.clone()
+        target_ids[:, :-trg_len] = -100  # set all but last trg_len tokens to -100
+
+        # Forward pass;
+        with torch.no_grad():
+            outputs = model(input_ids, labels=target_ids)
+
+            # loss is calculated using CrossEntropyLoss which averages over input tokens.
+            # Multiply it with trg_len to get the summation instead of average.
+            # We will take average over all the tokens to get the true average
+            # in the last step of this example.
+            neg_log_likelihood = outputs.loss * trg_len
+
+        nlls.append(neg_log_likelihood)
+
+        prev_end_loc = end_loc
+        if end_loc >= seq_len:
+            break
+
+    results[model_name] = torch.stack(nlls).sum() / end_loc
+    print(results)

--- a/src/chemnlp/data_val/config.py
+++ b/src/chemnlp/data_val/config.py
@@ -43,9 +43,10 @@ class TrainerConfig(BaseModel):
 
 class WandbConfig(BaseModel):
     enabled: bool = False
-    project: str = "chemnlp"
+    project: str = "LLCheM"
     group: str
     name: str
+    entity: str = "chemnlp"
 
 
 class TrainPipelineConfig(BaseModel):

--- a/src/chemnlp/data_val/config.py
+++ b/src/chemnlp/data_val/config.py
@@ -11,6 +11,7 @@ class Model(BaseModel):
     base: str
     name: str
     revision: str
+    checkpoint_path: Optional[str] = None
 
 
 class PromptTune(BaseModel):
@@ -21,7 +22,7 @@ class PromptTune(BaseModel):
 
 class TrainerConfig(BaseModel):
     output_dir: str
-    num_train_epochs: int = 1
+    num_train_epochs: float = 1.0
     learning_rate: float = 3e-4
     bf16: bool = False
     fp16: bool = False


### PR DESCRIPTION
Set-up and configs for fine-tuning experiments done at 1B. In particular:

- [x] Add README for conducting experiments.
- [x] Set-up Weights and Biases to log to `chemnlp` team page [here](https://stability.wandb.io/chemnlp/LLCheM). 
- [x] Add config for 1B model.
- [x] Add ability to load from checkpoint. 
- [x] Add saving of model at end of training.
- [x] Minor config changes to support partial epoch training. 
- [x] Add file to calculate NLL for different models.