### PR TITLE
updated default eval config

### DIFF
--- a/experiments/configs/hugging-face/eval_configs/eval_pipeline_config.yaml
+++ b/experiments/configs/hugging-face/eval_configs/eval_pipeline_config.yaml
@@ -1,0 +1,8 @@
+model: hf-causal
+model_args: "pretrained=/fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_1b/checkpoint-final"
+# "pretrained=EleutherAI/pythia-1b"
+tasks: "hendrycksTest-college_biology,hendrycksTest-college_chemistry,hendrycksTest-college_mathematics,hendrycksTest-college_physics,hendrycksTest-high_school_mathematics,hendrycksTest-high_school_biology,hendrycksTest-high_school_chemistry,hendrycksTest-high_school_physics"
+wandb_log: true
+wandb_project: LLCheM
+wandb_group: evaluation
+wandb_run_name: 1B_fullfinetune_STEM

--- a/experiments/configs/hugging-face/eval_configs/eval_pipeline_config.yaml
+++ b/experiments/configs/hugging-face/eval_configs/eval_pipeline_config.yaml
@@ -1,6 +1,6 @@
 model: hf-causal
 model_args: "pretrained=/fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_1b/checkpoint-final"
-# "pretrained=EleutherAI/pythia-1b"
+# model_args: "pretrained=EleutherAI/pythia-1b"
 tasks: "hendrycksTest-college_biology,hendrycksTest-college_chemistry,hendrycksTest-college_mathematics,hendrycksTest-college_physics,hendrycksTest-high_school_mathematics,hendrycksTest-high_school_biology,hendrycksTest-high_school_chemistry,hendrycksTest-high_school_physics"
 wandb_log: true
 wandb_project: LLCheM

--- a/experiments/configs/hugging-face/eval_pipeline_160M.yaml
+++ b/experiments/configs/hugging-face/eval_pipeline_160M.yaml
@@ -1,6 +1,0 @@
-model: hf-causal
-pre_trained_path: EleutherAI/pythia-160m
-tasks: "hendrycksTest-college_biology,hendrycksTest-college_chemistry,hendrycksTest-high_school_biology,hendrycksTest-high_school_chemistry"
-wandb_log: true
-wandb_project: LLCheM
-wandb_run_name: eval_baseline_160M

--- a/experiments/configs/hugging-face/eval_pipeline_160M_finetuned.yaml
+++ b/experiments/configs/hugging-face/eval_pipeline_160M_finetuned.yaml
@@ -1,6 +1,0 @@
-model: hf-causal
-pre_trained_path: /fsx/proj-chemnlp/experiments/checkpoints/finetuned/full_160M/checkpoint-1600
-tasks: "hendrycksTest-college_biology,hendrycksTest-college_chemistry,hendrycksTest-high_school_biology,hendrycksTest-high_school_chemistry"
-wandb_log: true
-wandb_project: LLCheM
-wandb_run_name: eval_baseline_fine_tuned160M


### PR DESCRIPTION
Created just one example eval config with new model_args and wandb_group. Contains example of loading locally and from hf.