### PR TITLE
added save_strategy to trainer config

### DIFF
--- a/src/chemnlp/data_val/config.py
+++ b/src/chemnlp/data_val/config.py
@@ -29,6 +29,7 @@ class TrainerConfig(BaseModel):
     evaluation_strategy: str = "steps"
     logging_steps: int = 50
     eval_steps: int = 100
+    save_strategy: str = "steps"
     save_steps: int = 100
     dataloader_num_workers: int = 0
     per_device_train_batch_size: int = 32


### PR DESCRIPTION
Added save strategy option to the trainer config which allows the save checkpoints to be incremented as epochs rather than steps