### PR TITLE
Change to Other to avoid confusion

### DIFF
--- a/data/caco2_wang/transform.py
+++ b/data/caco2_wang/transform.py
@@ -80,8 +80,8 @@ through the human intestinal tissue.""",
         "identifiers": [
             {
                 "id": "SMILES",  # column name
-                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "OTHER"
-                "description": "SMILES",  # description (optional, except for "OTHER")
+                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "Other"
+                "description": "SMILES",  # description (optional, except for "Other")
             },
             {
                 "id": "compound_name",

--- a/data/chebi_20/transform.py
+++ b/data/chebi_20/transform.py
@@ -25,8 +25,8 @@ META_TEMPLATE = {
     "identifiers": [
         {
             "id": "SMILES",  # column name
-            "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "OTHER"
-            "description": "SMILES",  # description (optional, except for "OTHER")
+            "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "Other"
+            "description": "SMILES",  # description (optional, except for "Other")
         },
     ],
     "license": "CC BY 4.0",  # license under which the original dataset was published

--- a/data/chembl_v29/transform.py
+++ b/data/chembl_v29/transform.py
@@ -52,8 +52,8 @@ to aid the translation of genomic information into effective new drugs.""",
         "identifiers": [
             {
                 "id": "SMILES",  # column name
-                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "OTHER"
-                "description": "SMILES",  # description (optional, except for "OTHER")
+                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "Other"
+                "description": "SMILES",  # description (optional, except for "Other")
             },
         ],
         "license": "CC BY-SA 3.0",  # license under which the original dataset was published

--- a/data/freesolv/transform.py
+++ b/data/freesolv/transform.py
@@ -104,8 +104,8 @@ def get_and_transform_data():
         "identifiers": [
             {
                 "id": "SMILES",  # column name
-                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "OTHER"
-                "description": "SMILES",  # description (optional, except for "OTHER")
+                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "Other"
+                "description": "SMILES",  # description (optional, except for "Other")
             },
             {
                 "id": "iupac_name",

--- a/data/lipophilicity/transform.py
+++ b/data/lipophilicity/transform.py
@@ -58,8 +58,8 @@ def get_and_transform_data():
         "identifiers": [
             {
                 "id": "SMILES",  # column name
-                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "OTHER"
-                "description": "SMILES",  # description (optional, except for "OTHER")
+                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "Other"
+                "description": "SMILES",  # description (optional, except for "Other")
             },
         ],
         "license": "CC BY-SA 3.0",  # license under which the original dataset was published

--- a/data/moses/transform.py
+++ b/data/moses/transform.py
@@ -52,8 +52,8 @@ It is processed from the ZINC Clean Leads dataset.""",
         "identifiers": [
             {
                 "id": "SMILES",  # column name
-                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "OTHER"
-                "description": "SMILES",  # description (optional, except for "OTHER")
+                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "Other"
+                "description": "SMILES",  # description (optional, except for "Other")
             },
         ],
         "license": "CC BY 4.0",  # license under which the original dataset was published

--- a/data/zinc/transform.py
+++ b/data/zinc/transform.py
@@ -44,8 +44,8 @@ TDC uses a 250,000 sampled version from the original Mol-VAE paper.""",
         "identifiers": [
             {
                 "id": "SMILES",  # column name
-                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "OTHER"
-                "description": "SMILES",  # description (optional, except for "OTHER")
+                "type": "SMILES",  # can be "SMILES", "SELFIES", "IUPAC", "Other"
+                "description": "SMILES",  # description (optional, except for "Other")
             },
         ],
         # license under which the original dataset was published


### PR DESCRIPTION
In some comments we used `OTHER` instead of `Other`. This PR fixes that to avoid confusion.