### PR TITLE
Enabled reusable conda env

### DIFF
--- a/experiments/scripts/env_creation_hf.sh
+++ b/experiments/scripts/env_creation_hf.sh
@@ -13,16 +13,20 @@ CONDA_BASE=$(conda info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh
 
 # Create Python environment through conda
-if [ -d "${CONDA_ENV_PATH}" ]; then rm -Rf ${CONDA_ENV_PATH}; fi
-conda create --force --prefix ${CONDA_ENV_PATH} python=${PYTHON_VER} -y
-conda activate ${CONDA_ENV_PATH}
+if [ -d "${CONDA_ENV_PATH}" ]
+then 
+    # if already exists activate
+    echo "Found ${CONDA_ENV_PATH} in the directory, activating it!"
+    conda activate ${CONDA_ENV_PATH}
+else
+    # otherwise create new env (race conditions exist)
+    echo "Creating ${CONDA_ENV_PATH} environment!"
+    conda create --force --prefix ${CONDA_ENV_PATH} python=${PYTHON_VER} -y
+    conda activate ${CONDA_ENV_PATH}
 
-# Python requirements
-## cd into your directory inside of proj-chemnlp
-cd /fsx/proj-chemnlp/$2
+    ## clone + submodules (ok if exists)
+    cd /fsx/proj-chemnlp/$2
+    [ ! -d 'chemnlp' ] && git clone --recurse-submodules git@github.com:OpenBioML/chemnlp.git
 
-## clone + submodules (ok if exists)
-[ ! -d 'chemnlp' ] && git clone --recurse-submodules git@github.com:OpenBioML/chemnlp.git
-
-## install core requirements
-conda install -y pytorch torchvision torchaudio pytorch-cuda=${CUDA_VERSION} -c pytorch -c nvidia --verbose
+    ## install core requirements
+    conda install -y pytorch torchvision torchaudio pytorch-cuda=${CUDA_VERSION} -c pytorch -c nvidia --verbose

--- a/experiments/scripts/env_creation_hf.sh
+++ b/experiments/scripts/env_creation_hf.sh
@@ -8,6 +8,7 @@ export CONDA_ENV_PATH=/fsx/proj-chemnlp/$1/conda/env/chemnlp-hf
 export PYTHON_VER=3.8
 CUDA_VERSION=11.7
 CONDA_BASE=$(conda info --base)
+CHEMNLP_PATH=/fsx/proj-chemnlp/$2/chemnlp
 
 ## ensure we can use activate syntax in slurm scripts
 source $CONDA_BASE/etc/profile.d/conda.sh
@@ -30,3 +31,6 @@ else
 
     ## install core requirements
     conda install -y pytorch torchvision torchaudio pytorch-cuda=${CUDA_VERSION} -c pytorch -c nvidia --verbose
+    cd $CHEMNLP_PATH
+    pip install ".[training]"
+fi

--- a/experiments/scripts/env_creation_hf.sh
+++ b/experiments/scripts/env_creation_hf.sh
@@ -15,7 +15,7 @@ source $CONDA_BASE/etc/profile.d/conda.sh
 
 # Create Python environment through conda
 if [ -d "${CONDA_ENV_PATH}" ]
-then 
+then
     # if already exists activate
     echo "Found ${CONDA_ENV_PATH} in the directory, activating it!"
     conda activate ${CONDA_ENV_PATH}

--- a/experiments/scripts/sbatch_train_hf.sh
+++ b/experiments/scripts/sbatch_train_hf.sh
@@ -25,10 +25,7 @@ CHEMNLP_PATH=/fsx/proj-chemnlp/$2/chemnlp
 # create environment
 source $CHEMNLP_PATH/experiments/scripts/env_creation_hf.sh $1 $2
 
-# install extras
-cd $CHEMNLP_PATH
-pip install ".[training]"
-
 # trigger run
+cd $CHEMNLP_PATH
 python -m torch.distributed.launch --use-env --nnodes 1 --nproc-per-node 8 \
     experiments/scripts/run_tune.py experiments/configs/hugging-face/$3


### PR DESCRIPTION
* closes #229 

This PR changes the `env_creation_hf.sh` script to only create a new conda environment if that environment does not already exist on the cluster. This allows multiple job runs to reuse the same conda environment, saving us ≅ 12 minutes per training experiment in time. It also moves any stray training package installations into the environment script.