### PR TITLE
feat: add torch_compile option

### DIFF
--- a/src/chemnlp/data_val/config.py
+++ b/src/chemnlp/data_val/config.py
@@ -40,6 +40,7 @@ class TrainerConfig(BaseModel):
     per_device_eval_batch_size: int = 32
     gradient_checkpointing: bool = False
     deepspeed_config: Optional[str] = None
+    torch_compile: bool = False
 
     @validator("learning_rate")
     def small_positive_learning_rate(cls, v):


### PR DESCRIPTION
This PR adds an option to use `torch.compile` through the [appropriate argument](https://github.com/huggingface/transformers/blob/849367ccf741d8c58aa88ccfe1d52d8636eaf2b7/src/transformers/training_args.py#L575) in HuggingFace's `TrainingArguments`.

In my experiments, with recent versions of PyTorch and Transformers, this resulted in faster training and slightly lower GPU memory usage; more details about my experiments can be found in the discussion in #173. With this change, we can simply add `torch_compile: true` in the config files in `chemnlp/experiments/configs` under the `trainer` section to use `torch.compile`, for instance, in the following line: https://github.com/OpenBioML/chemnlp/blob/97d6b3ff40453dcfe84918260d143d1ead2e074e/experiments/configs/hugging-face/160M_full.yml#L30-L31