### PR TITLE
Make test size configurable

### DIFF
--- a/experiments/scripts/run_tune.py
+++ b/experiments/scripts/run_tune.py
@@ -80,7 +80,7 @@ def run(config_path: str, config_overrides: Optional[Dict] = None) -> None:
     )
 
     dataset = datasets.load_from_disk(config.data.path)
-    split_dataset = dataset.train_test_split(test_size=0.025)
+    split_dataset = dataset.train_test_split(test_size=config.data.validation_size)
     data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
 
     training_args = TrainingArguments(

--- a/src/chemnlp/data_val/config.py
+++ b/src/chemnlp/data_val/config.py
@@ -8,6 +8,13 @@ DictofLists = Dict[str, List]
 
 class Data(BaseModel):
     path: str
+    validation_size: float = 0.05
+
+    @validator("validation_size")
+    def small_positive_validation_size(cls, v):
+        if v < 0 or v > 1:
+            raise ValueError("Specify a positive validation split size (0,1)")
+        return v
 
 
 class Model(BaseModel):


### PR DESCRIPTION
Small change to ensure the language modelling validation split size if configurable from the `Data` config model.