### PR TITLE
Fix validation split for all tokenised datasets

### DIFF
--- a/experiments/scripts/run_tune.py
+++ b/experiments/scripts/run_tune.py
@@ -80,7 +80,9 @@ def run(config_path: str, config_overrides: Optional[Dict] = None) -> None:
     )
 
     dataset = datasets.load_from_disk(config.data.path)
-    split_dataset = dataset.train_test_split(test_size=config.data.validation_size)
+    split_dataset = dataset.train_test_split(
+        test_size=config.data.validation_size, shuffle=False
+    )
     data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
 
     training_args = TrainingArguments(


### PR DESCRIPTION
* closes #262

This hardcodes `shuffle = False` so we can ensure runs on the same datasets are seeing exactly the same set of samples and crucially have the same validation split. I'm quite sure we don't want this as a parameter because we'd never want it to be random?