### PR TITLE
add backslash to install local repo

### DIFF
--- a/experiments/scripts/env_creation_hf.sh
+++ b/experiments/scripts/env_creation_hf.sh
@@ -33,5 +33,5 @@ else
     conda install -y pytorch torchvision torchaudio pytorch-cuda=${CUDA_VERSION} -c pytorch -c nvidia --verbose
     cd $CHEMNLP_PATH
     pip install ".[training]"
-    pip install lm-evaluation-harness
+    pip install lm-evaluation-harness/
 fi


### PR DESCRIPTION
* Adds a small change to the env creation script which ensures we install a local directory called `lm-evaluation-harness/` and not search for a package called `lm-evaluation-harness` remotely.