### PR TITLE
Add S3 dataset storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,9 @@ dataset_creation = [
 training = [
         "deepspeed>=0.8.2", # https://github.com/microsoft/DeepSpeed/pull/2863
         "nvidia-ml-py3",
-        "protobuf<3.20"
+        "protobuf<3.20",
+        "s3fs",
+        "boto3<=1.26.90", # https://github.com/boto/boto3/issues/3648
 ]
 
 [tool.setuptools_scm]

--- a/src/chemnlp/data_val/config.py
+++ b/src/chemnlp/data_val/config.py
@@ -7,7 +7,7 @@ DictofLists = Dict[str, List]
 
 
 class Data(BaseModel):
-    path: str
+    path: str  # can be local or S3 directory
     validation_size: float = 0.05
 
     @validator("validation_size")


### PR DESCRIPTION
* closes #274 

As Hugging Face already supports S3 storage options through the `datasets.load_from_disk()`, we can freely replace any `/fsx/` dataset paths to S3 storage paths for our training pipeline. We just need to install additional packages.

It's also supposedly quite memory efficient due to the use of [Arrow](https://huggingface.co/docs/datasets/about_arrow) so it seems we might not have to worry too much about very large datasets. After testing this on a 10M token subset of Wikipedia (results [here](https://stability.wandb.io/chemnlp/LLCheM/groups/1B-10Mwikipedia-optimisation-grid)) we don't observe any slowdown in training speed when switching from `/fsx/` (EFS) to S3 storage of the training dataset.