### PR TITLE
Add s3 checkpoint transfer

### DIFF
--- a/experiments/scripts/run_eval.sh
+++ b/experiments/scripts/run_eval.sh
@@ -3,8 +3,8 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=12
-#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/testing_%j.out
-#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/testing_%j.err
+#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/eval_%j.out
+#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/eval_%j.err
 #SBATCH --open-mode=append
 #SBATCH --account=topchem
 #SBATCH --partition=g40

--- a/experiments/scripts/run_eval_batch.sh
+++ b/experiments/scripts/run_eval_batch.sh
@@ -3,8 +3,8 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=12
-#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/testing_%j.out
-#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/testing_%j.err
+#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/batch_eval_%j.out
+#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/batch_eval_%j.err
 #SBATCH --open-mode=append
 #SBATCH --account=topchem
 #SBATCH --partition=g40
@@ -30,6 +30,5 @@ python $CHEMNLP_PATH/experiments/scripts/eval_create_batch_configs.py $3 $4
 # evaluate each model
 for entry in $4/*/
 do
-  sbatch $CHEMNLP_PATH/experiments/scripts/run_eval.sh $1 $2 "$entry"eval_config.yml
-  sleep 1
+  python $CHEMNLP_PATH/lm-evaluation-harness/main_eval.py "$entry"eval_config.yml
 done

--- a/experiments/scripts/run_eval_batch.sh
+++ b/experiments/scripts/run_eval_batch.sh
@@ -30,5 +30,6 @@ python $CHEMNLP_PATH/experiments/scripts/eval_create_batch_configs.py $3 $4
 # evaluate each model
 for entry in $4/*/
 do
-  python $CHEMNLP_PATH/lm-evaluation-harness/main_eval.py "$entry"eval_config.yml
+  sbatch $CHEMNLP_PATH/experiments/scripts/run_eval.sh $1 $2 "$entry"eval_config.yml
+  sleep 1
 done

--- a/experiments/scripts/sbatch_train_hf.sh
+++ b/experiments/scripts/sbatch_train_hf.sh
@@ -3,8 +3,8 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=12
-#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/job_%j.out
-#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/job_%j.err
+#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/training_%j.out
+#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/training_%j.err
 #SBATCH --open-mode=append
 #SBATCH --account=topchem
 #SBATCH --partition=g40

--- a/experiments/scripts/sbatch_train_hf_multinode.sh
+++ b/experiments/scripts/sbatch_train_hf_multinode.sh
@@ -3,8 +3,8 @@
 #SBATCH --nodes=4
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=12
-#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/job_%j.out
-#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/job_%j.err
+#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/training_%j.out
+#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/training_%j.err
 #SBATCH --open-mode=append
 #SBATCH --account=topchem
 #SBATCH --partition=g40

--- a/experiments/scripts/transfer_all_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_all_checkpoint_to_s3.sh
@@ -1,10 +1,10 @@
 #! /bin/bash
-#SBATCH --job-name="llchem-transfer"
+#SBATCH --job-name="llchem-transfer-batch"
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=12
-#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/transfer_%j.out
-#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/transfer_%j.err
+#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/transfer_batch_%j.out
+#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/transfer_batch_%j.err
 #SBATCH --open-mode=append
 #SBATCH --account=topchem
 #SBATCH --partition=g40
@@ -26,6 +26,7 @@ all_checkpoints=( $(find $1 -name "checkpoint-*" -type d) )
 echo "Saving checkpoints to region: $EC2_REGION"
 for chkpt in ${all_checkpoints[@]}
 do
-    sbatch $CHEMNLP_PATH/experiments/scripts/transfer_checkpoint_to_s3.sh $chkpt $2
+    echo $CHEMNLP_PATH/experiments/scripts/transfer_checkpoint_to_s3.sh $chkpt $2
+    # sbatch $CHEMNLP_PATH/experiments/scripts/transfer_checkpoint_to_s3.sh $chkpt $2
     sleep 1
 done

--- a/experiments/scripts/transfer_all_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_all_checkpoint_to_s3.sh
@@ -26,7 +26,6 @@ all_checkpoints=( $(find $1 -name "checkpoint-*" -type d) )
 echo "Saving checkpoints to region: $EC2_REGION"
 for chkpt in ${all_checkpoints[@]}
 do
-    echo $CHEMNLP_PATH/experiments/scripts/transfer_checkpoint_to_s3.sh $chkpt $2
-    # sbatch $CHEMNLP_PATH/experiments/scripts/transfer_checkpoint_to_s3.sh $chkpt $2
+    sbatch $CHEMNLP_PATH/experiments/scripts/transfer_checkpoint_to_s3.sh $chkpt $2
     sleep 1
 done

--- a/experiments/scripts/transfer_all_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_all_checkpoint_to_s3.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+#SBATCH --job-name="llchem-transfer"
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=12
+#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/transfer_%j.out
+#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/transfer_%j.err
+#SBATCH --open-mode=append
+#SBATCH --account=topchem
+#SBATCH --partition=g40
+#SBATCH --exclusive
+
+## This script recursively copies a directory to S3 storage
+### The first arg ($1) is the full path to a folder (i.e. <....>/1B_experiments/)
+### The second arg ($2) is the S3 bucket to copy to (i.e. llchem-models)
+### The third argument is the directory inside proj-chemnlp to find chemnlp
+
+EC2_AVAIL_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
+EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed 's/[a-z]$//'`"
+CHEMNLP_PATH=/fsx/proj-chemnlp/$3/chemnlp
+CHECKPOINT_DIR=/fsx/proj-chemnlp/experiments/checkpoints
+
+echo "Finding checkpoints in $1"
+all_checkpoints=( $(find $1 -name "checkpoint-*" -type d) )
+
+echo "Saving checkpoints to region: $EC2_REGION"
+for chkpt in ${all_checkpoints[@]}
+do
+    sbatch $CHEMNLP_PATH/experiments/scripts/transfer_checkpoint_to_s3.sh $chkpt $2
+    sleep 1
+done

--- a/experiments/scripts/transfer_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_checkpoint_to_s3.sh
@@ -14,7 +14,7 @@
 ### The first arg ($1) is a full path to a checkpoint folder (i.e. <....>/checkpoint-1000)
 ### The second arg ($2) is the S3 bucket to copy to (i.e. llchem-models)
 
-cutat=checkpoints
+cutat=checkpoints/
 TARGET_DIR=$(echo $1 | awk -F $cutat '{print $2}')
 PARENT_DIR="$(dirname "$1")"
 CHILD_FILE="$(basename "$1")"
@@ -24,4 +24,4 @@ if [ ! -f "$1.tar" ]; then
     cd $PARENT_DIR && tar -cvf $CHILD_FILE.tar $CHILD_FILE
 fi
 
-aws s3 cp $1.tar s3://$TARGET_DIR.tar
+aws s3 cp $1.tar s3://$2/$TARGET_DIR.tar

--- a/experiments/scripts/transfer_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_checkpoint_to_s3.sh
@@ -15,11 +15,10 @@
 ### The second arg ($2) is the S3 bucket to copy to (i.e. llchem-models)
 
 cutat=checkpoints/
-TARGET_DIR=$(echo $1 | awk -F $cutat '{print $2}')
+TARGET_DIR=$(echo $1 | awk -F $cutat '{print $2}') # turns /a/b/checkpoints/c/d/ -> c/d/
 PARENT_DIR="$(dirname "$1")"
 CHILD_FILE="$(basename "$1")"
 
-# sync only transfers new files from the source directory
 if [ ! -f "$1.tar" ]; then
     cd $PARENT_DIR && tar -cvf $CHILD_FILE.tar $CHILD_FILE
 fi

--- a/experiments/scripts/transfer_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_checkpoint_to_s3.sh
@@ -24,5 +24,8 @@ TARGET_DIR=s3://$2/$SUBDIR
 echo "Copying from $1 to ${TARGET_DIR}"
 
 # sync only transfers new files from the source directory
-cd $PARENT_DIR && tar -cvf $CHILD_FILE.tar $CHILD_FILE
+if [ ! -f "$1.tar" ]; then
+    cd $PARENT_DIR && tar -cvf $CHILD_FILE.tar $CHILD_FILE
+fi
+
 aws s3 cp $1.tar $TARGET_DIR.tar

--- a/experiments/scripts/transfer_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_checkpoint_to_s3.sh
@@ -1,10 +1,10 @@
 #! /bin/bash
-#SBATCH --job-name="llchem-transfer-batch"
+#SBATCH --job-name="llchem-transfer"
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=12
-#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/transfer_batch_%j.out
-#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/transfer_batch_%j.err
+#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/transfer_%j.out
+#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/transfer_%j.err
 #SBATCH --open-mode=append
 #SBATCH --account=topchem
 #SBATCH --partition=g40
@@ -15,7 +15,7 @@
 ### The second arg ($2) is the S3 bucket to copy to (i.e. llchem-models)
 
 CHECKPOINT_DIR=/fsx/proj-chemnlp/experiments/checkpoints
-SUBDIR=${$1#"$CHECKPOINT_DIR"}  # get diff
+SUBDIR=${"$1"#"$CHECKPOINT_DIR"}  # get diff
 
 PARENT_DIR="$(dirname "$1")"
 CHILD_FILE="$(basename "$1")"
@@ -28,4 +28,12 @@ if [ ! -f "$1.tar" ]; then
     cd $PARENT_DIR && tar -cvf $CHILD_FILE.tar $CHILD_FILE
 fi
 
-aws s3 cp $1.tar $TARGET_DIR.tar
+echo $CHECKPOINT_DIR
+echo $1
+echo $SUBDIR
+echo $TARGET_DIR
+
+echo $PARENT_DIR
+echo $CHILD_FILE
+
+# aws s3 cp $1.tar $TARGET_DIR.tar

--- a/experiments/scripts/transfer_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_checkpoint_to_s3.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+#SBATCH --job-name="llchem-transfer-batch"
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=12
+#SBATCH --output=/fsx/proj-chemnlp/experiments/logs/transfer_batch_%j.out
+#SBATCH --error=/fsx/proj-chemnlp/experiments/logs/transfer_batch_%j.err
+#SBATCH --open-mode=append
+#SBATCH --account=topchem
+#SBATCH --partition=g40
+#SBATCH --exclusive
+
+## This script recursively copies a directory to S3 storage
+### The first arg ($1) is a full path to a checkpoint folder (i.e. <....>/checkpoint-1000)
+### The second arg ($2) is the S3 bucket to copy to (i.e. llchem-models)
+
+CHECKPOINT_DIR=/fsx/proj-chemnlp/experiments/checkpoints
+SUBDIR=${$1#"$CHECKPOINT_DIR"}  # get diff
+
+PARENT_DIR="$(dirname "$1")"
+CHILD_FILE="$(basename "$1")"
+TARGET_DIR=s3://$2/$SUBDIR
+
+echo "Copying from $1 to ${TARGET_DIR}"
+
+# sync only transfers new files from the source directory
+cd $PARENT_DIR && tar -cvf $CHILD_FILE.tar $CHILD_FILE
+aws s3 cp $1.tar $TARGET_DIR.tar

--- a/experiments/scripts/transfer_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_checkpoint_to_s3.sh
@@ -19,11 +19,9 @@ TARGET_DIR=$(echo $1 | awk -F $cutat '{print $2}')
 PARENT_DIR="$(dirname "$1")"
 CHILD_FILE="$(basename "$1")"
 
-echo "Copying from $1 to ${TARGET_DIR}"
-
 # sync only transfers new files from the source directory
 if [ ! -f "$1.tar" ]; then
     cd $PARENT_DIR && tar -cvf $CHILD_FILE.tar $CHILD_FILE
 fi
 
-aws s3 cp $1.tar $TARGET_DIR.tar
+aws s3 cp $1.tar s3://$TARGET_DIR.tar

--- a/experiments/scripts/transfer_checkpoint_to_s3.sh
+++ b/experiments/scripts/transfer_checkpoint_to_s3.sh
@@ -14,12 +14,10 @@
 ### The first arg ($1) is a full path to a checkpoint folder (i.e. <....>/checkpoint-1000)
 ### The second arg ($2) is the S3 bucket to copy to (i.e. llchem-models)
 
-CHECKPOINT_DIR=/fsx/proj-chemnlp/experiments/checkpoints
-SUBDIR=${"$1"#"$CHECKPOINT_DIR"}  # get diff
-
+cutat=checkpoints
+TARGET_DIR=$(echo $1 | awk -F $cutat '{print $2}')
 PARENT_DIR="$(dirname "$1")"
 CHILD_FILE="$(basename "$1")"
-TARGET_DIR=s3://$2/$SUBDIR
 
 echo "Copying from $1 to ${TARGET_DIR}"
 
@@ -28,12 +26,4 @@ if [ ! -f "$1.tar" ]; then
     cd $PARENT_DIR && tar -cvf $CHILD_FILE.tar $CHILD_FILE
 fi
 
-echo $CHECKPOINT_DIR
-echo $1
-echo $SUBDIR
-echo $TARGET_DIR
-
-echo $PARENT_DIR
-echo $CHILD_FILE
-
-# aws s3 cp $1.tar $TARGET_DIR.tar
+aws s3 cp $1.tar $TARGET_DIR.tar


### PR DESCRIPTION
* closes #275 
* some other adhoc changes
* FYI we've two S3 storage buckets called `llchem-models` & `llchem-data`, I was thinking these could somewhat mirror `/fsx/proj-chemnlp/experiments/checkpoints` and `/fsx/proj-chemnlp/data` respectively?

This PR adds functionality to transfer model checkpoints to S3 storage. It also uses `tar` to combine multiple disparate files into one object. 

It does not delete any files from `/fsx` as I think the user will want to delete those once they've verified it has worked as expected. It typically takes seconds to transfer a single 1B parameter model's checkpoint folder.