### PR TITLE
Reverse ordering of type coercion

### DIFF
--- a/src/chemnlp/data_val/config.py
+++ b/src/chemnlp/data_val/config.py
@@ -50,7 +50,7 @@ class TrainerConfig(BaseModel):
     gradient_checkpointing: bool = False
     deepspeed_config: Optional[str] = None
     torch_compile: bool = False
-    restart_checkpoint: Union[str, bool] = True
+    restart_checkpoint: Union[bool, str] = True
 
     @validator("learning_rate")
     def small_positive_learning_rate(cls, v):


### PR DESCRIPTION
* This was breaking the ability to fine-tune a model without using existing checkpoints even if they exist.

Pydantic tries to match the input arguments to the types specified as type hints **until** it reaches one that's a possible match and then converts the type. This meant anything of `False` in the yaml files was converted to `"False"` because the `str` was before `bool`.