### PR TITLE
add default multiprocessing for loading / saving datasets

### DIFF
--- a/experiments/data/prepare_hf_dataset.py
+++ b/experiments/data/prepare_hf_dataset.py
@@ -57,7 +57,10 @@ def run(config_path: str):
     save_path = (
         f"{config.out_dir}/{config.model_name}/hf_{config.dataset_name.split('/')[-1]}"
     )
-    tokenised_data.save_to_disk(save_path)
+    tokenised_data.save_to_disk(
+        save_path,
+        num_proc=os.cpu_count(),
+    )
 
     with open(f"{save_path}/summary_statistics.json", "w") as f:
         f.write(json.dumps(summary_stats))

--- a/experiments/data/prepare_hf_dataset.py
+++ b/experiments/data/prepare_hf_dataset.py
@@ -29,7 +29,9 @@ def run(config_path: str):
     if not tokenizer.pad_token:
         tokenizer.add_special_tokens({"pad_token": "<|padding|>"})
 
-    dataset = datasets.load_dataset(config.dataset_name, **config.dataset_args, num_proc=os.cpu_count())
+    dataset = datasets.load_dataset(
+        config.dataset_name, **config.dataset_args, num_proc=os.cpu_count()
+    )
 
     tokenised_data = dataset.map(
         lambda batch: tokenise(

--- a/experiments/data/prepare_hf_dataset.py
+++ b/experiments/data/prepare_hf_dataset.py
@@ -29,7 +29,7 @@ def run(config_path: str):
     if not tokenizer.pad_token:
         tokenizer.add_special_tokens({"pad_token": "<|padding|>"})
 
-    dataset = datasets.load_dataset(config.dataset_name, **config.dataset_args)
+    dataset = datasets.load_dataset(config.dataset_name, **config.dataset_args, num_proc=os.cpu_count())
 
     tokenised_data = dataset.map(
         lambda batch: tokenise(

--- a/experiments/data/prepare_mixed_data.py
+++ b/experiments/data/prepare_mixed_data.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 
 import datasets
 
@@ -39,7 +40,10 @@ def run(config_path: str) -> None:
     mixed_data = datasets.concatenate_datasets(dataset_slices)
     mixed_data = mixed_data.shuffle(seed=RANDOM_SEED)
 
-    mixed_data.save_to_disk(config.save_path)
+    mixed_data.save_to_disk(
+        config.save_path,
+        num_proc=os.cpu_count(),
+    )
 
     summary_stats = {
         "random_state": RANDOM_SEED,


### PR DESCRIPTION
* Adds multiprocessing for more efficient dataset saving.

This should significantly speedup dataset saving as we now can save different shards in parallel without being blocked by a slow "for loop" style saving.

As per [here](https://github.com/huggingface/datasets/blob/2.13.0/src/datasets/arrow_dataset.py#L1439) in `datasets.save_to_disk`, the number of processes defaults to 1 preventing any parallelisation in data saving.
```python
num_proc = num_proc if num_proc is not None else 1
```

This was also added to `datasets.load_dataset` for downloading large datasets.