### PR TITLE
Pin transformers version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ training = [
         "protobuf<3.20",
         "s3fs",
         "boto3<=1.26.90", # https://github.com/boto/boto3/issues/3648
-        "transformers<4.30",
+        "transformers<4.30", # https://github.com/huggingface/transformers/issues/24359
 ]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ training = [
         "protobuf<3.20",
         "s3fs",
         "boto3<=1.26.90", # https://github.com/boto/boto3/issues/3648
+        "transformers<4.30",
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
* A big change involving deepspeed was introduced in recent `transformers` 4.30+ which broke our previous pipeline configurations. This is now pinned for the time being until it's fixed.