### PR TITLE
Misc training changes

### DIFF
--- a/experiments/configs/deepspeed/deepspeed_S1.json
+++ b/experiments/configs/deepspeed/deepspeed_S1.json
@@ -5,15 +5,6 @@
     "bf16": {
         "enabled": true
     },
-    "optimizer": {
-        "type": "AdamW",
-        "params": {
-            "lr": "auto",
-            "betas": "auto",
-            "eps": "auto",
-            "weight_decay": "auto"
-        }
-    },
     "zero_optimization": {
         "stage": 1,
         "overlap_comm": true,

--- a/experiments/configs/deepspeed/deepspeed_S2.json
+++ b/experiments/configs/deepspeed/deepspeed_S2.json
@@ -5,15 +5,6 @@
     "bf16": {
         "enabled": true
     },
-    "optimizer": {
-        "type": "AdamW",
-        "params": {
-            "lr": "auto",
-            "betas": "auto",
-            "eps": "auto",
-            "weight_decay": "auto"
-        }
-    },
     "zero_optimization": {
         "stage": 2,
         "offload_optimizer": {

--- a/experiments/configs/deepspeed/deepspeed_offload_S2.json
+++ b/experiments/configs/deepspeed/deepspeed_offload_S2.json
@@ -5,15 +5,6 @@
     "bf16": {
         "enabled": true
     },
-    "optimizer": {
-        "type": "AdamW",
-        "params": {
-            "lr": "auto",
-            "betas": "auto",
-            "eps": "auto",
-            "weight_decay": "auto"
-        }
-    },
     "zero_optimization": {
         "stage": 2,
         "offload_optimizer": {

--- a/experiments/configs/deepspeed/deepspeed_offload_S3.json
+++ b/experiments/configs/deepspeed/deepspeed_offload_S3.json
@@ -5,15 +5,6 @@
     "bf16": {
         "enabled": true
     },
-    "optimizer": {
-        "type": "AdamW",
-        "params": {
-            "lr": "auto",
-            "betas": "auto",
-            "eps": "auto",
-            "weight_decay": "auto"
-        }
-    },
     "zero_optimization": {
         "stage": 3,
         "offload_optimizer": {

--- a/experiments/scripts/sbatch_train_hf.sh
+++ b/experiments/scripts/sbatch_train_hf.sh
@@ -29,5 +29,5 @@ source $CHEMNLP_PATH/experiments/scripts/env_creation_hf.sh $1 $2
 
 # trigger run
 cd $CHEMNLP_PATH
-python -m torch.distributed.launch --use-env --nnodes 1 --nproc-per-node 8 \
+torchrun --standalone --nnodes 1 --nproc-per-node 8 \
     experiments/scripts/run_tune.py experiments/configs/hugging-face/$3 --config_overrides $overrides

--- a/experiments/scripts/sbatch_train_hf_multinode.sh
+++ b/experiments/scripts/sbatch_train_hf_multinode.sh
@@ -21,6 +21,7 @@ export TOKENIZERS_PARALLELISM=false
 export WANDB_BASE_URL="https://stability.wandb.io"
 export NCCL_DEBUG=INFO
 export NCCL_ASYNC_ERROR_HANDLING=1
+export LOGLEVEL=INFO
 overrides=${4:-'{}'}
 
 # set workdir
@@ -37,7 +38,7 @@ head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
 echo Node IP: $head_node_ip
 
 # Run script
-srun python -m torch.distributed.launch --use-env --nnodes $SLURM_NNODES --nproc_per_node 8 \
+srun torchrun --nnodes $SLURM_NNODES --nproc_per_node 8 \
 --rdzv_id $RANDOM \
 --rdzv_backend c10d \
 --rdzv_endpoint $head_node_ip:29500 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ training = [
         "protobuf<3.20",
         "s3fs",
         "boto3<=1.26.90", # https://github.com/boto/boto3/issues/3648
-        "transformers<4.30", # https://github.com/huggingface/transformers/issues/24359
 ]
 
 tokenisation = [


### PR DESCRIPTION
* Reverts the transformer pin as the original configuration update has been done.
    * We currently default to only using Hugging Face optimisers.
    * We can use [DeepSpeed optimisers](https://www.deepspeed.ai/docs/config-json/#optimizer-parameters) if we want but these cannot be paired with HF schedulers we must also specify the scheduler in DeepSpeed
* Upgraded our launcher to use [torchrun](https://pytorch.org/docs/stable/elastic/run.html) as it's recommended by PyTorch documentation.
* Added extra logs for multinode training through `LOGLEVEL` which allows us to see PyTorch details when it's configuring the pool of nodes.