### PR TITLE
Prevent double last model checkpoint

### DIFF
--- a/experiments/scripts/run_tune.py
+++ b/experiments/scripts/run_tune.py
@@ -151,7 +151,8 @@ def run(config_path: str, config_overrides: Optional[Dict] = None) -> None:
             training_args.output_dir, config.trainer.restart_checkpoint
         )
     )
-    trainer.save_model(config.trainer.output_dir + "/checkpoint-final")
+    if config.trainer.save_strategy == "steps":
+        trainer.save_model(config.trainer.output_dir + "/checkpoint-final")
 
     if config.wandb.enabled:
         # custom logging at end of training


### PR DESCRIPTION
Add a clause to only save the final checkpoint if the `save_strategy` is "steps" as otherwise the `Trainer` already saves one at end of epochs