### PR TITLE
Use torchrun over python launcher for multi-gpu

### DIFF
--- a/experiments/scripts/run_eval.sh
+++ b/experiments/scripts/run_eval.sh
@@ -25,4 +25,4 @@ source $CHEMNLP_PATH/experiments/scripts/env_creation_hf.sh $1 $2
 
 # trigger run
 cd $CHEMNLP_PATH/lm-evaluation-harness
-python main_eval.py $3
+torchrun --standalone --nnodes 1 --nproc-per-node 8 main_eval.py $3


### PR DESCRIPTION
* Contributes to speeding up evaluation pipeline by ensuring on each node we use all 8 GPUs rather than 1 GPU. 
* Should result in **8x speedup of the pipeline**.
* No change to underlying configuration, just a larger effective batch size as now we run `<batch-size> x 8` for each evaluation task

See a working example of how this happens for [this WandB run](https://stability.wandb.io/chemnlp/LLCheM/groups/eval_22B_pubmed_2epoch/).