### PR TITLE
Update tasks datasets

### DIFF
--- a/experiments/data/prepare_lm_eval_dataset.py
+++ b/experiments/data/prepare_lm_eval_dataset.py
@@ -7,18 +7,18 @@ Example Usage:
 
 import argparse
 import json
-import os
 
 import datasets
 import lm_eval.tasks
 from transformers import AutoTokenizer
 
-from chemnlp.data.utils import tokenise
+from chemnlp.data.utils import get_tokenised_data_minimum_padding
 from chemnlp.data_val.config import LMEvalDataConfig
 from chemnlp.utils import load_config
 
 STRING_KEY = "TEXT"
 RANDOM_SEED = 1234
+EOS_TOKEN = "\n\n"
 
 
 def make_dataset(tasks, data_split):
@@ -38,9 +38,9 @@ def make_dataset(tasks, data_split):
         task_sizes[task_name] = len(task_docs)
 
         for doc in task_docs:
-            docs.append(doc["query"] + doc["choices"][doc["gold"]])
+            docs.append(f'{doc["query"]} {doc["choices"][doc["gold"]]}{EOS_TOKEN}')
 
-    return datasets.Dataset.from_dict({STRING_KEY: docs}), task_sizes
+    return docs, task_sizes
 
 
 if __name__ == "__main__":
@@ -62,23 +62,22 @@ if __name__ == "__main__":
         data_split=config.data_split,
     )
 
-    tokenised_data = dataset.map(
-        lambda batch: tokenise(batch, tokenizer, config.context_length, STRING_KEY),
-        remove_columns=dataset.column_names,
-        batched=True,
-        batch_size=1,
-        num_proc=os.cpu_count(),
-        load_from_cache_file=False,
+    processed_data = get_tokenised_data_minimum_padding(
+        dataset=dataset,
+        tokenizer=tokenizer,
+        max_length=config.context_length,
+        eos_string=EOS_TOKEN,
     )
-    tokenised_data = tokenised_data.shuffle(seed=RANDOM_SEED)
+    processed_data = datasets.Dataset.from_dict(processed_data)
 
     summary_stats = {
         "model_name": config.model_name,
-        "total_samples": tokenised_data.num_rows,
+        "total_samples": processed_data.num_rows,
         "samples_per_task": task_sizes,
         "max_context_length": config.context_length,
-        "total_tokens_in_billions": round(
-            config.context_length * tokenised_data.num_rows / 1e9, 4
+        "total_tokens": config.context_length * processed_data.num_rows,
+        "total_padded_tokens_in_billions": round(
+            config.context_length * processed_data.num_rows / 1e9, 4
         ),
         "data_split_collected": config.data_split,
     }
@@ -87,6 +86,10 @@ if __name__ == "__main__":
     save_path = (
         f"{config.out_dir}/{config.model_name}/{config.save_name}_{config.data_split}"
     )
-    tokenised_data.save_to_disk(save_path)
-    with open(f"{save_path}/summary_statistics.json", "w") as f:
-        f.write(json.dumps(summary_stats))
+    processed_data.save_to_disk(save_path)
+    if "s3" in save_path:
+        # yet to be implemented
+        pass
+    else:
+        with open(f"{save_path}/summary_statistics.json", "w") as f:
+            f.write(json.dumps(summary_stats))

--- a/experiments/data/prepare_smiles_dataset.py
+++ b/experiments/data/prepare_smiles_dataset.py
@@ -6,7 +6,6 @@ Example Usage:
 """
 
 import argparse
-import itertools
 import json
 
 import datasets
@@ -14,7 +13,7 @@ from numpy import random
 from rdkit import Chem, RDLogger
 from transformers import AutoTokenizer
 
-from chemnlp.data.utils import pad_sequence
+from chemnlp.data.utils import get_tokenised_data_minimum_padding
 from chemnlp.data_val.config import LMEvalDataConfig
 from chemnlp.utils import load_config
 
@@ -55,62 +54,6 @@ def _get_smiles_string(doc):
     )
 
 
-def concatenate_samples_without_splitting(dataset, tokenizer, max_length):
-    """concatenate samples into batches upto max_length without
-    splitting any of the individual samples between batches"""
-
-    tok_articles = [tokenizer(x)["input_ids"] for x in dataset]
-    tok_articles = [sample for sample in tok_articles if len(sample) <= max_length]
-    tok_articles = list(itertools.chain.from_iterable(tok_articles))
-    eos_token = tokenizer.encode(EOS_TOKEN)[0]
-
-    concatenated_articles = []
-    p0, p1, last_eos = 0, 1, 0
-    while p1 < len(tok_articles):
-        if tok_articles[p1] == eos_token:
-            if (p1 - p0 + 1) < max_length:
-                # keep track of most recent eos index, continue exploring
-                last_eos = p1
-
-            elif (p1 - p0 + 1) == max_length:
-                # collect whole pointer window
-                concatenated_articles.append(tok_articles[p0 : p1 + 1])
-                last_eos = p1
-                p0 = p1 + 1
-                p1 = p0
-            else:
-                # max_length exceeded, collect only up to last eos
-                concatenated_articles.append(tok_articles[p0 : last_eos + 1])
-                p0 = last_eos + 1
-                p1 = p0
-        p1 += 1
-
-    # collect final batch
-    concatenated_articles.append(tok_articles[p0:])
-    return concatenated_articles
-
-
-def pad_batched_data(dataset, tokenizer, max_length):
-    padded_sequences_all = []
-    attention_masks_all = []
-
-    for article in dataset:
-        if len(article) < max_length:
-            article, attention_masks = pad_sequence(
-                article, max_length, tokenizer.pad_token_id
-            )
-        else:
-            attention_masks = [1] * max_length
-        padded_sequences_all.append(article)
-        attention_masks_all.append(attention_masks)
-
-    return {
-        "input_ids": padded_sequences_all,
-        "token_type_ids": [[0] * max_length] * len(padded_sequences_all),
-        "attention_mask": attention_masks_all,
-    }
-
-
 def run(config):
     random.seed(seed=SEED)
 
@@ -129,21 +72,22 @@ def run(config):
     if not tokenizer.pad_token:
         tokenizer.add_special_tokens({"pad_token": "<|padding|>"})
 
-    batched_data = concatenate_samples_without_splitting(
-        mixed_data, tokenizer, config.context_length
+    processed_data = get_tokenised_data_minimum_padding(
+        dataset=mixed_data,
+        tokenizer=tokenizer,
+        max_length=config.context_length,
+        eos_string=EOS_TOKEN,
     )
-    total_tokens = sum([len(batch) for batch in batched_data])
-    processed_data = pad_batched_data(batched_data, tokenizer, config.context_length)
     processed_data = datasets.Dataset.from_dict(processed_data)
 
     summary_stats = {
         "model_name": config.model_name,
         "total_samples": processed_data.num_rows,
         "max_context_length": config.context_length,
+        "total_tokens": config.context_length * processed_data.num_rows,
         "total_padded_tokens_in_billions": round(
             config.context_length * processed_data.num_rows / 1e9, 4
         ),
-        "total_tokens_in_billions": round(total_tokens / 1e9, 4),
         "data_split_collected": config.data_split,
     }
 

--- a/experiments/data/prepare_smiles_dataset.py
+++ b/experiments/data/prepare_smiles_dataset.py
@@ -33,20 +33,20 @@ SEED = 1234
 
 
 def process_docs(docs):
-    valid = map(_get_smile_string, docs)
-    invalid = map(_process_invalid_smile, docs)
+    valid = map(_get_smiles_string, docs)
+    invalid = map(_process_invalid_smiles, docs)
     mixed_data = list(valid) + list(invalid)
     mixed_data = [string for pair in mixed_data for string in pair]
     return random.choice(mixed_data, len(mixed_data)).tolist()
 
 
-def _process_invalid_smile(doc):
-    invalid_smile = doc[: random.randint(1, len(doc))]
-    return _get_smile_string(invalid_smile)
+def _process_invalid_smiles(doc):
+    invalid_smiles = doc[: random.randint(1, len(doc))]
+    return _get_smiles_string(invalid_smiles)
 
 
-def _get_smile_string(doc):
-    is_valid = Chem.MolFromSmiles(doc)
+def _get_smiles_string(doc):
+    is_valid = Chem.MolFromsmiles(doc)
     lift_answer = INVALID_LIFT_A if is_valid is None else VALID_LIFT_A
     prefix = INVALID_PREFIX if is_valid is None else VALID_PREFIX
     return (

--- a/src/chemnlp/data/utils.py
+++ b/src/chemnlp/data/utils.py
@@ -58,7 +58,7 @@ def tokenise(
 
 
 def get_tokenised_data_minimum_padding(
-    dataset: list,
+    dataset: List,
     tokenizer: PreTrainedTokenizer,
     max_length: int,
     eos_string: str,
@@ -78,7 +78,7 @@ def get_tokenised_data_minimum_padding(
 
 
 def _concatenate_samples_without_splitting(
-    dataset: list,
+    dataset: List,
     tokenizer: PreTrainedTokenizer,
     max_length: int,
     eos_string: str,
@@ -118,7 +118,7 @@ def _concatenate_samples_without_splitting(
 
 
 def _pad_batched_data(
-    dataset: list,
+    dataset: List,
     tokenizer: PreTrainedTokenizer,
     max_length: int,
 ):

--- a/src/chemnlp/data/utils.py
+++ b/src/chemnlp/data/utils.py
@@ -50,13 +50,83 @@ def tokenise(
     tok_articles = list(itertools.chain.from_iterable(tok_articles))
     tok_articles = list(chunks(tok_articles, max_length))
 
+    return _pad_batched_data(
+        dataset=tok_articles,
+        tokenizer=tokenizer,
+        max_length=max_length,
+    )
+
+
+def get_tokenised_data_minimum_padding(
+    dataset: list,
+    tokenizer: PreTrainedTokenizer,
+    max_length: int,
+    eos_string: str,
+) -> Dict[str, List]:
+    batched_data = _concatenate_samples_without_splitting(
+        dataset=dataset,
+        tokenizer=tokenizer,
+        max_length=max_length,
+        eos_string=eos_string,
+    )
+
+    return _pad_batched_data(
+        dataset=batched_data,
+        tokenizer=tokenizer,
+        max_length=max_length,
+    )
+
+
+def _concatenate_samples_without_splitting(
+    dataset: list,
+    tokenizer: PreTrainedTokenizer,
+    max_length: int,
+    eos_string: str,
+):
+    """concatenate samples into batches upto max_length without
+    splitting any of the individual samples between batches"""
+
+    tok_articles = [tokenizer(x)["input_ids"] for x in dataset]
+    tok_articles = [sample for sample in tok_articles if len(sample) <= max_length]
+    tok_articles = list(itertools.chain.from_iterable(tok_articles))
+    eos_token = tokenizer.encode(eos_string)[0]
+
+    concatenated_articles = []
+    p0, p1, last_eos = 0, 1, 0
+    while p1 < len(tok_articles):
+        if tok_articles[p1] == eos_token:
+            if (p1 - p0 + 1) < max_length:
+                # keep track of most recent eos index, continue exploring
+                last_eos = p1
+
+            elif (p1 - p0 + 1) == max_length:
+                # collect whole pointer window
+                concatenated_articles.append(tok_articles[p0 : p1 + 1])
+                last_eos = p1
+                p0 = p1 + 1
+                p1 = p0
+            else:
+                # max_length exceeded, collect only up to last eos
+                concatenated_articles.append(tok_articles[p0 : last_eos + 1])
+                p0 = last_eos + 1
+                p1 = p0
+        p1 += 1
+
+    # collect final batch
+    concatenated_articles.append(tok_articles[p0:])
+    return concatenated_articles
+
+
+def _pad_batched_data(
+    dataset: list,
+    tokenizer: PreTrainedTokenizer,
+    max_length: int,
+):
     padded_sequences_all = []
     attention_masks_all = []
 
-    # Since articles are stitched together at the batch level
-    # we might need to pad the last article
-    for article in tok_articles:
-        if len(article) != max_length:
+    for article in dataset:
+        if len(article) < max_length:
             article, attention_masks = pad_sequence(
                 article, max_length, tokenizer.pad_token_id
             )


### PR DESCRIPTION
Updated this script so we can create training data which is batched efficiently for the periodic table dataset which should have a train/dev/test split now. The smiles and lm-eval datasets are small enough that we can do this batching but I haven't updated e.g. the hf datasets script because they are normally just large blocks of text where this isn't needed and would be too slow.
Since the functions are reused between the two scripts, I moved them into utils.