### PR TITLE
Add custom HF `LLcheMTrainer`

### DIFF
--- a/experiments/scripts/run_tune.py
+++ b/experiments/scripts/run_tune.py
@@ -16,7 +16,6 @@ from peft import PromptTuningConfig, PromptTuningInit, TaskType, get_peft_model
 from transformers import (
     AutoTokenizer,
     DataCollatorForLanguageModeling,
-    Trainer,
     TrainingArguments,
 )
 
@@ -27,6 +26,7 @@ from chemnlp.utils import (
     get_local_ip_address,
     load_config,
 )
+from chemnlp.trainer import LLcheMTrainer
 
 FILE_PATH = pathlib.Path(__file__).parent.resolve()
 CONFIG_DIR = FILE_PATH.parent / "configs"
@@ -138,7 +138,7 @@ def run(config_path: str, config_overrides: Optional[Dict] = None) -> None:
         )
 
     # start train or auto-restart
-    trainer = Trainer(
+    trainer = LLcheMTrainer(
         model=model,
         args=training_args,
         train_dataset=split_dataset["train"],

--- a/experiments/scripts/run_tune.py
+++ b/experiments/scripts/run_tune.py
@@ -20,13 +20,13 @@ from transformers import (
 )
 
 from chemnlp.data_val.config import TrainPipelineConfig
+from chemnlp.trainer import LLcheMTrainer
 from chemnlp.utils import (
     collect_cpu_memory,
     collect_gpu_memory,
     get_local_ip_address,
     load_config,
 )
-from chemnlp.trainer import LLcheMTrainer
 
 FILE_PATH = pathlib.Path(__file__).parent.resolve()
 CONFIG_DIR = FILE_PATH.parent / "configs"

--- a/src/chemnlp/trainer.py
+++ b/src/chemnlp/trainer.py
@@ -20,6 +20,7 @@ class LLcheMTrainer(Trainer):
         """
         Rewritten over from transformers 4.30.2
         * custom sampler
+        * custom optional dataloader shuffling
         * all other kwargs get passed as normal
         """
         super().__init__(**kwargs)

--- a/src/chemnlp/trainer.py
+++ b/src/chemnlp/trainer.py
@@ -11,7 +11,7 @@ from transformers.utils import is_datasets_available
 
 
 class LLcheMTrainer(Trainer):
-    def __init__(self, sampler: Optional[sampler.Sampler] = None, **kwargs):
+    def __init__(self, sampler: Optional[sampler.Sampler] = None, shuffle_dataloader: Optional[bool] = True, **kwargs):
         """
         Rewritten over from transformers 4.30.2
         * custom sampler
@@ -19,6 +19,7 @@ class LLcheMTrainer(Trainer):
         """
         super().__init__(**kwargs)
         self.sampler = sampler
+        self.shuffle_dataloader = shuffle_dataloader
 
     def get_train_dataloader(self) -> DataLoader:
         """
@@ -55,6 +56,7 @@ class LLcheMTrainer(Trainer):
                 collate_fn=data_collator,
                 num_workers=self.args.dataloader_num_workers,
                 pin_memory=self.args.dataloader_pin_memory,
+                shuffle=self.shuffle_dataloader
             )
 
         # NOTE change from original code
@@ -69,4 +71,5 @@ class LLcheMTrainer(Trainer):
             num_workers=self.args.dataloader_num_workers,
             pin_memory=self.args.dataloader_pin_memory,
             worker_init_fn=seed_worker,
+            shuffle=self.shuffle_dataloader
         )

--- a/src/chemnlp/trainer.py
+++ b/src/chemnlp/trainer.py
@@ -55,7 +55,8 @@ class LLcheMTrainer(Trainer):
                 pin_memory=self.args.dataloader_pin_memory,
             )
 
-        train_sampler = self._get_train_sampler()
+        # NOTE change from original code
+        train_sampler = self.sampler if self.sampler else self._get_train_sampler()
 
         return DataLoader(
             train_dataset,

--- a/src/chemnlp/trainer.py
+++ b/src/chemnlp/trainer.py
@@ -1,0 +1,70 @@
+"""A custom trainer for modifying data sampling behaviour"""
+from typing import Optional
+import torch
+import datasets
+from torch.utils.data import DataLoader, sampler
+from transformers import Trainer
+from transformers.trainer_pt_utils import IterableDatasetShard
+from transformers.trainer_utils import seed_worker
+from transformers.utils import is_datasets_available
+
+class LLcheMTrainer(Trainer):
+    def __init__(
+        self,
+        sampler: Optional[sampler.Sampler] = None,
+        **kwargs
+    ):
+        """
+        Rewritten over from transformers 4.30.2
+        * custom sampler
+        * all other kwargs get passed as normal
+        """
+        super().__init__(**kwargs)
+        self.sampler = sampler
+
+    def get_train_dataloader(self) -> DataLoader:
+        """
+        Returns the training [`~torch.utils.data.DataLoader`].
+        Uses default transformers behaviour unless a custom sampler is provided.
+        """
+        if self.train_dataset is None:
+            raise ValueError("Trainer: training requires a train_dataset.")
+
+        train_dataset = self.train_dataset
+        data_collator = self.data_collator
+        if is_datasets_available() and isinstance(train_dataset, datasets.Dataset):
+            train_dataset = self._remove_unused_columns(train_dataset, description="training")
+        else:
+            data_collator = self._get_collator_with_removed_columns(data_collator, description="training")
+
+        if isinstance(train_dataset, torch.utils.data.IterableDataset):
+            if self.args.world_size > 1:
+                train_dataset = IterableDatasetShard(
+                    train_dataset,
+                    batch_size=self._train_batch_size,
+                    drop_last=self.args.dataloader_drop_last,
+                    num_processes=self.args.world_size,
+                    process_index=self.args.process_index,
+                )
+
+            return DataLoader(
+                train_dataset,
+                batch_size=self._train_batch_size,
+                collate_fn=data_collator,
+                num_workers=self.args.dataloader_num_workers,
+                pin_memory=self.args.dataloader_pin_memory,
+            )
+
+        train_sampler = self._get_train_sampler()
+
+        return DataLoader(
+            train_dataset,
+            batch_size=self._train_batch_size,
+            sampler=train_sampler,
+            collate_fn=data_collator,
+            drop_last=self.args.dataloader_drop_last,
+            num_workers=self.args.dataloader_num_workers,
+            pin_memory=self.args.dataloader_pin_memory,
+            worker_init_fn=seed_worker,
+        )
+    

--- a/src/chemnlp/trainer.py
+++ b/src/chemnlp/trainer.py
@@ -1,19 +1,17 @@
 """A custom trainer for modifying data sampling behaviour"""
 from typing import Optional
-import torch
+
 import datasets
+import torch
 from torch.utils.data import DataLoader, sampler
 from transformers import Trainer
 from transformers.trainer_pt_utils import IterableDatasetShard
 from transformers.trainer_utils import seed_worker
 from transformers.utils import is_datasets_available
 
+
 class LLcheMTrainer(Trainer):
-    def __init__(
-        self,
-        sampler: Optional[sampler.Sampler] = None,
-        **kwargs
-    ):
+    def __init__(self, sampler: Optional[sampler.Sampler] = None, **kwargs):
         """
         Rewritten over from transformers 4.30.2
         * custom sampler
@@ -33,9 +31,13 @@ class LLcheMTrainer(Trainer):
         train_dataset = self.train_dataset
         data_collator = self.data_collator
         if is_datasets_available() and isinstance(train_dataset, datasets.Dataset):
-            train_dataset = self._remove_unused_columns(train_dataset, description="training")
+            train_dataset = self._remove_unused_columns(
+                train_dataset, description="training"
+            )
         else:
-            data_collator = self._get_collator_with_removed_columns(data_collator, description="training")
+            data_collator = self._get_collator_with_removed_columns(
+                data_collator, description="training"
+            )
 
         if isinstance(train_dataset, torch.utils.data.IterableDataset):
             if self.args.world_size > 1:
@@ -68,4 +70,3 @@ class LLcheMTrainer(Trainer):
             pin_memory=self.args.dataloader_pin_memory,
             worker_init_fn=seed_worker,
         )
-    

--- a/src/chemnlp/trainer.py
+++ b/src/chemnlp/trainer.py
@@ -11,7 +11,12 @@ from transformers.utils import is_datasets_available
 
 
 class LLcheMTrainer(Trainer):
-    def __init__(self, sampler: Optional[sampler.Sampler] = None, shuffle_dataloader: Optional[bool] = True, **kwargs):
+    def __init__(
+        self,
+        sampler: Optional[sampler.Sampler] = None,
+        shuffle_dataloader: Optional[bool] = True,
+        **kwargs,
+    ):
         """
         Rewritten over from transformers 4.30.2
         * custom sampler
@@ -56,7 +61,7 @@ class LLcheMTrainer(Trainer):
                 collate_fn=data_collator,
                 num_workers=self.args.dataloader_num_workers,
                 pin_memory=self.args.dataloader_pin_memory,
-                shuffle=self.shuffle_dataloader
+                shuffle=self.shuffle_dataloader,
             )
 
         # NOTE change from original code
@@ -71,5 +76,5 @@ class LLcheMTrainer(Trainer):
             num_workers=self.args.dataloader_num_workers,
             pin_memory=self.args.dataloader_pin_memory,
             worker_init_fn=seed_worker,
-            shuffle=self.shuffle_dataloader
+            shuffle=self.shuffle_dataloader,
         )


### PR DESCRIPTION
closes #355 

Subclasses the HF `Trainer` to allow for 
* more complex data sampling regimes
* optional shuffling of dataloaders each epoch

This should enable the addition of new samplers so we can do an empirical comparison during our finetuning experiments on EuroPMC between 4 epochs of either;
1) randomly shuffled tokens
2) sliding window over chronologically ordered tokens

We would need to subclass the `DistributedSampler` to ensure we had correct indexes being sent to each GPU device. However, in general it seems fairly straightforward.