### PR TITLE
updated bioavailability_ma_et_al

### DIFF
--- a/data/tabular/bioavailability_ma_et_al/transform.py
+++ b/data/tabular/bioavailability_ma_et_al/transform.py
@@ -124,7 +124,7 @@ journal = {Journal of Pharmaceutical and Biomedical Analysis}""",
             "The {SMILES__description} {SMILES#} represents a molecule that is {bioavailable#not &NULL}identified as {bioavailable__names__adjective}.",  # noqa: E501
             "The {SMILES__description} {SMILES#} is {bioavailable#not &NULL}{bioavailable__names__adjective}.",
             "The molecule {SMILES#} is {bioavailable#not &NULL}{bioavailable__names__adjective}.",
-            "Is the {SMILES__description} {SMILES#} {bioavailable__names__adjective}?:<EOI> {bioavailable#yes&no}",  # noqa: E501 for the benchmarking setup <EOI> separates input and output
+            "Is the {SMILES__description} {SMILES#} {bioavailable__names__adjective}? <EOI> {bioavailable#yes&no}",  # noqa: E501 for the benchmarking setup <EOI> separates input and output
             """Task: Please answer the multiple choice question below with {%multiple_choice_enum%2%aA1}.
 Question: Is the molecule with the {SMILES__description} representation {SMILES#} {bioavailable__names__adjective}?
 Options:

--- a/data/tabular/bioavailability_ma_et_al/transform.py
+++ b/data/tabular/bioavailability_ma_et_al/transform.py
@@ -58,8 +58,7 @@ available at the site of action.""",
                 "type": "boolean",
                 "names": [  # names for the property (to sample from for building the prompts)
                     {"noun": "oral bioavailability"},
-                    {"noun": "bioavailability"},
-                    {"adjective": "bioavailable"},
+                    {"adjective": "orally bioavailable"},
                 ],
                 "uris": [
                     "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C70913",
@@ -99,6 +98,8 @@ available at the site of action.""",
             {
                 "url": "https://tdcommons.ai/single_pred_tasks/adme/#bioavailability-ma-et-al",
                 "description": "data source",
+                # note: this is not the original data, it is their modified version
+                # original larger dataset: http://modem.ucsd.edu/adme/databases/databases_bioavailability.htm
             },
         ],
         "num_points": len(df),  # number of datapoints in this dataset
@@ -118,19 +119,19 @@ oral bioavailability derived by using GA-CG-SVM method},
 journal = {Journal of Pharmaceutical and Biomedical Analysis}""",
         ],
         "templates": [
-            "The molecule with the {SMILES__description} representation of {SMILES#} is {bioavailable#not &NULL}{bioavailable__names__adjective}.",  # noqa: E501
+            "The molecule with the {SMILES__description} representation {SMILES#} is {bioavailable#not &NULL}{bioavailable__names__adjective}.",  # noqa: E501
             "Based on the {SMILES__description} representation {SMILES#}, the molecule is {bioavailable#not &NULL}{bioavailable__names__adjective}.",  # noqa: E501
             "The {SMILES__description} {SMILES#} represents a molecule that is {bioavailable#not &NULL}identified as {bioavailable__names__adjective}.",  # noqa: E501
             "The {SMILES__description} {SMILES#} is {bioavailable#not &NULL}{bioavailable__names__adjective}.",
             "The molecule {SMILES#} is {bioavailable__names__adjective}.",
-            "Is the {SMILES__description} {SMILES#} {bioavailable__names__adjective}:<EOI> {bioavailable#yes&no}",  # noqa: E501 for the benchmarking setup <EOI> separates input and output
+            "Is the {SMILES__description} {SMILES#} {bioavailable__names__adjective}?:<EOI> {bioavailable#yes&no}",  # noqa: E501 for the benchmarking setup <EOI> separates input and output
             """Task: Please answer the multiple choice question below with {%multiple_choice_enum%2%aA1}.
-Question: Is the molecule with the {SMILES__description} representation of {SMILES#} {bioavailable__names__adjective}?
+Question: Is the molecule with the {SMILES__description} representation {SMILES#} {bioavailable__names__adjective}?
 Options:
 {bioavailable%}
 Answer: {%multiple_choice_result}""",
             """Task: Please answer the multiple choice question below with {%multiple_choice_enum%2%aA1}.
-Question: Is the molecule with the {SMILES__description} representation of {SMILES#} {bioavailable__names__adjective}?
+Question: Is the molecule with the {SMILES__description} representation {SMILES#} {bioavailable__names__adjective}?
 Options:
 {bioavailable%}
 Answer:<EOI> {%multiple_choice_result}""",

--- a/data/tabular/bioavailability_ma_et_al/transform.py
+++ b/data/tabular/bioavailability_ma_et_al/transform.py
@@ -123,7 +123,7 @@ journal = {Journal of Pharmaceutical and Biomedical Analysis}""",
             "Based on the {SMILES__description} representation {SMILES#}, the molecule is {bioavailable#not &NULL}{bioavailable__names__adjective}.",  # noqa: E501
             "The {SMILES__description} {SMILES#} represents a molecule that is {bioavailable#not &NULL}identified as {bioavailable__names__adjective}.",  # noqa: E501
             "The {SMILES__description} {SMILES#} is {bioavailable#not &NULL}{bioavailable__names__adjective}.",
-            "The molecule {SMILES#} is {bioavailable__names__adjective}.",
+            "The molecule {SMILES#} is {bioavailable#not &NULL}{bioavailable__names__adjective}.",
             "Is the {SMILES__description} {SMILES#} {bioavailable__names__adjective}?:<EOI> {bioavailable#yes&no}",  # noqa: E501 for the benchmarking setup <EOI> separates input and output
             """Task: Please answer the multiple choice question below with {%multiple_choice_enum%2%aA1}.
 Question: Is the molecule with the {SMILES__description} representation {SMILES#} {bioavailable__names__adjective}?


### PR DESCRIPTION
Updated the templates for this task to improve grammar and that this data is only for the bioavailability via oral pathway.
Note: Oral bioavailability is not really a binary task, it should be a fraction. This paper classified oral bioavailability as “positive” if its bioavailability≥ 20%, otherwise “negative” because they needed it to be binary for their SVM model to do classification. 
This means that we might need to think more about this task, some options:
* Leave it as it is right now
* Use the raw data instead of the SVM binary data: this would change it to a continuous task: http://modem.ucsd.edu/adme/databases/databases_bioavailability.htm
* Change the templates to be a bit more vague but stick with the existing data e.g. instead of this SMILES 'is orally bioavailable', we could say this SMILES has 'high oral bioavailability', or 'is likely to show oral bioavailability'. 
Happy to discuss what we think is best :) 