### PR TITLE
Add filter for str

### DIFF
--- a/experiments/data/prepare_hf_dataset.py
+++ b/experiments/data/prepare_hf_dataset.py
@@ -33,9 +33,13 @@ def run(config_path: str):
     dataset = datasets.load_dataset(
         config.dataset_name, **config.dataset_args, num_proc=os.cpu_count()
     )
-    filtered_ds = dataset.filter(lambda x: isinstance(x[config.string_key], str), num_proc=os.cpu_count())
-    print(f"Removed {dataset.num_rows-filtered_ds.num_rows} samples due as not str type.")
-    
+    filtered_ds = dataset.filter(
+        lambda x: isinstance(x[config.string_key], str), num_proc=os.cpu_count()
+    )
+    print(
+        f"Removed {dataset.num_rows-filtered_ds.num_rows} samples due as not str type."
+    )
+
     tokenised_data = filtered_ds.map(
         lambda batch: tokenise(
             batch, tokenizer, config.context_length, config.string_key
@@ -46,7 +50,7 @@ def run(config_path: str):
         num_proc=os.cpu_count(),
         load_from_cache_file=False,
     )
-    
+
     summary_stats = {
         "model_name": config.model_name,
         "dataset_name": config.dataset_name,

--- a/experiments/data/prepare_hf_dataset.py
+++ b/experiments/data/prepare_hf_dataset.py
@@ -37,7 +37,7 @@ def run(config_path: str):
         lambda x: isinstance(x[config.string_key], str), num_proc=os.cpu_count()
     )
     print(
-        f"Removed {dataset.num_rows-filtered_ds.num_rows} samples due as not str type."
+        f"Removed {dataset.num_rows-filtered_ds.num_rows} samples as not of type str."
     )
 
     tokenised_data = filtered_ds.map(

--- a/experiments/data/prepare_hf_dataset.py
+++ b/experiments/data/prepare_hf_dataset.py
@@ -33,21 +33,24 @@ def run(config_path: str):
     dataset = datasets.load_dataset(
         config.dataset_name, **config.dataset_args, num_proc=os.cpu_count()
     )
-
-    tokenised_data = dataset.map(
+    filtered_ds = dataset.filter(lambda x: isinstance(x[config.string_key], str), num_proc=os.cpu_count())
+    print(f"Removed {dataset.num_rows-filtered_ds.num_rows} samples due as not str type.")
+    
+    tokenised_data = filtered_ds.map(
         lambda batch: tokenise(
             batch, tokenizer, config.context_length, config.string_key
         ),
         batched=True,
         batch_size=config.batch_size,
-        remove_columns=dataset.column_names,
+        remove_columns=filtered_ds.column_names,
         num_proc=os.cpu_count(),
         load_from_cache_file=False,
     )
+    
     summary_stats = {
         "model_name": config.model_name,
         "dataset_name": config.dataset_name,
-        "total_samples": dataset.num_rows,
+        "total_samples": filtered_ds.num_rows,
         "dataset_args": config.dataset_args,
         "max_context_length": config.context_length,
         "total_tokens_in_billions": round(


### PR DESCRIPTION
* A 36+ hour tokenisation run for the full text papers failed because **ONE** sample was not of type `str` and was instead of type `None` 😭
* This adds an initial filtering step to ensure all entries in the `config.string_key` are actually of `str` type