### PR TITLE
Adding odd-one-out dataset

### DIFF
--- a/data/tabular/odd_one_out/meta.yaml
+++ b/data/tabular/odd_one_out/meta.yaml
@@ -1,23 +1,23 @@
 ---
 name: odd_one_out
 description: |-
-  Tanimoto distance between Morgan fingerprints of SMILES in the ZINC dataset.
-  We performed filtering to exclude sequences of molecules where there is no strong difference.
+    Tanimoto distance between Morgan fingerprints of SMILES in the ZINC dataset.
+    We performed filtering to exclude sequences of molecules where there is no strong difference.
 targets:
     - id: smallest_similarities
       type: continuous
       description: smallest Tanimoto similarity between Morgan fingerprints
       names:
-        - noun: smallest Tanimoto similarity between Morgan fingerprints
+          - noun: smallest Tanimoto similarity between Morgan fingerprints
     - id: biggest_similarities
       type: continuous
       description: largest Tanimoto similarity between Morgan fingerprints
       names:
-        - noun: largest Tanimoto similarity between Morgan fingerprints
+          - noun: largest Tanimoto similarity between Morgan fingerprints
 benchmarks:
-  - name: TDC
-    link: https://tdcommons.ai/
-    split_column:  split
+    - name: TDC
+      link: https://tdcommons.ai/
+      split_column: split
 identifiers:
     - id: smi_1
       type: SMILES
@@ -39,12 +39,12 @@ identifiers:
       type: SMILES
     - id: biggest_sim_1
       type: SMILES
-      description: SMILES 
+      description: SMILES
     - id: most_diff_0
-      type: SMILES 
+      type: SMILES
       description: SMILES
     - id: most_diff_1
-      type: SMILES 
+      type: SMILES
       description: SMILES
 license: MIT
 num_points: 98715
@@ -59,30 +59,35 @@ bibtex:
         volume = {60},
         number = {12},
         pages = {6065--6073},
-        author = {John J. Irwin and Khanh G. Tang and Jennifer Young and Chinzorig Dandarchuluun 
+        author = {John J. Irwin and Khanh G. Tang and Jennifer Young and Chinzorig Dandarchuluun
         and Benjamin R. Wong and Munkhzul Khurelbaatar and Yurii S. Moroz and John Mayfield and Roger A. Sayle},
         title = {{ZINC}20{\textemdash}A Free Ultralarge-Scale Chemical Database for Ligand Discovery},
         journal = {J. Chem. Inf. Model.}
       }
 templates:
-  - |- 
-    Task: You are given a {#list|sequence!} of SMILES of {#molecules|chemicals|chemical compounds!} and {#must|are asked to!} find the {#molecule|chemical|compound!} that is {#most|maximally!} different from the others.
-    Molecules: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}
-    Constraint: Answer by returning the SMILES string. Similarity is measured in terms of Tanimoto distance between Morgan fingerprints of radius {#two|2!}.
-    Answer: {odd_one_out_mol#}
-  - |- 
-    Task: You are given a {#list|sequence!} of SMILES of {#molecules|chemicals|chemical compounds!} and {#must|are asked to!} find the pair {#molecule|chemical|compound!} that is {#most|maximally!} different from each other.
-    Molecules: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}
-    Constraint: Answer by returning two SMILES strings separated by a comma. Similarity is measured in terms of Tanimoto distance between Morgan fingerprints of radius {#two|2!}.
-    Answer: {most_diff_0#}, {most_diff_1#}
-  - |- 
-    Task: You are given a {#list|sequence!} of SMILES of {#molecules|chemicals|chemical compounds!} and {#must|are asked to!} find the pair {#molecule|chemical|compound!} that is {#most|maximally!} similar to each other.
-    Molecules: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}
-    Constraint: Answer by returning two SMILES strings separated by a comma. Similarity is measured in terms of Tanimoto distance between Morgan fingerprints of radius {#two|2!}.
-    Answer: {biggest_sim_1#}, {biggest_sim_0#}
-  - |- 
-    Question: I have a {#list|sequence!} of SMILES for {#molecules|chemicals|chemical compounds!}: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}. Which two molecules have the highest similarity based on their Tanimoto distance calculated from Morgan fingerprints of radius {#two|2!}?
-    Answer: The two most similar molecules are {biggest_sim_1#} and {biggest_sim_0#}.
-  - |- 
-    Question: I have the following SMILES strings: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}. Which {#molecule|chemical|chemical compound|compound!} is the most {#dissimilar|different!} from the others based on Tanimoto distance of their Morgan fingerprints of radius {#two|2!}?
-    Answer: The most dissimilar {#molecule|chemical|chemical compound|compound!} is {odd_one_out_mol#}.
+    - |-
+      Task: You are given a {#list|sequence!} of SMILES of {#molecules|chemicals|chemical compounds!} and {#must|are asked to!} find the {#molecule|chemical|compound!} that is {#most|maximally!} different from the others.
+      Molecules: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}
+      Constraint: Answer by returning the SMILES string. Similarity is measured in terms of Tanimoto distance between Morgan fingerprints of radius {#two|2!}.
+      Answer: {odd_one_out_mol#}
+    - |-
+      Task: You are given a {#list|sequence!} of SMILES of {#molecules|chemicals|chemical compounds!} and {#must|are asked to!} find the pair {#molecule|chemical|compound!} that is {#most|maximally!} different from each other.
+      Molecules: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}
+      Constraint: Answer by returning two SMILES strings separated by a comma. Similarity is measured in terms of Tanimoto distance between Morgan fingerprints of radius {#two|2!}.
+      Answer: {most_diff_0#}, {most_diff_1#}
+    - |-
+      Task: You are given a {#list|sequence!} of SMILES of {#molecules|chemicals|chemical compounds!} and {#must|are asked to!} find the pair {#molecule|chemical|compound!} that is {#most|maximally!} similar to each other.
+      Molecules: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}
+      Constraint: Answer by returning two SMILES strings separated by a comma. Similarity is measured in terms of Tanimoto distance between Morgan fingerprints of radius {#two|2!}.
+      Answer: {biggest_sim_1#}, {biggest_sim_0#}
+    - |-
+      Question: I have a {#list|sequence!} of SMILES for {#molecules|chemicals|chemical compounds!}: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}. Which two molecules have the highest similarity based on their Tanimoto distance calculated from Morgan fingerprints of radius {#two|2!}?
+      Answer: The two most similar molecules are {biggest_sim_1#} and {biggest_sim_0#}.
+    - |-
+      Question: I have the following SMILES strings: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}. Which {#molecule|chemical|chemical compound|compound!} is the most {#dissimilar|different!} from the all others based on Tanimoto distance of their Morgan fingerprints of radius {#two|2!}?
+      Answer: The most dissimilar {#molecule|chemical|chemical compound|compound!} is {odd_one_out_mol#}.
+    - |-
+      User: I have the following SMILES strings: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}. Which is the odd one in this list?
+      Assistant: {#Interesting question, what do you|Interesting, what do you|Cool, what do you|What do you!} {#mean by|understand as!} "odd one"?
+      User: {#For now, we|Let's assume we|We!} measure similarity in terms of Tanimoto distance between Morgan fingerprints of radius two. The "odd one" is the molecule that is most different from the others.
+      Assistant: {#In that case,|Then,!} I {#think|believe|propose!} that {odd_one_out_mol#} is the "odd one" you're looking for.

--- a/data/tabular/odd_one_out/meta.yaml
+++ b/data/tabular/odd_one_out/meta.yaml
@@ -1,0 +1,88 @@
+---
+name: odd_one_out
+description: |-
+  Tanimoto distance between Morgan fingerprints of SMILES in the ZINC dataset.
+  We performed filtering to exclude sequences of molecules where there is no strong difference.
+targets:
+    - id: smallest_similarities
+      type: continuous
+      description: smallest Tanimoto similarity between Morgan fingerprints
+      names:
+        - noun: smallest Tanimoto similarity between Morgan fingerprints
+    - id: biggest_similarities
+      type: continuous
+      description: largest Tanimoto similarity between Morgan fingerprints
+      names:
+        - noun: largest Tanimoto similarity between Morgan fingerprints
+benchmarks:
+  - name: TDC
+    link: https://tdcommons.ai/
+    split_column:  split
+identifiers:
+    - id: smi_1
+      type: SMILES
+      description: SMILES
+    - id: smi_2
+      type: SMILES
+      description: SMILES
+    - id: smi_3
+      type: SMILES
+      description: SMILES
+    - id: smi_4
+      type: SMILES
+      description: SMILES
+    - id: odd_one_out_mol
+      type: SMILES
+      description: SMILES
+    - id: biggest_sim_0
+      description: SMILES
+      type: SMILES
+    - id: biggest_sim_1
+      type: SMILES
+      description: SMILES 
+    - id: most_diff_0
+      type: SMILES 
+      description: SMILES
+    - id: most_diff_1
+      type: SMILES 
+      description: SMILES
+license: MIT
+num_points: 98715
+bibtex:
+    - |-
+      @article{Irwin_2020,
+        doi = {10.1021/acs.jcim.0c00675},
+        url = {https://doi.org/10.1021%2Facs.jcim.0c00675},
+        year = 2020,
+        month = {oct},
+        publisher = {American Chemical Society ({ACS})},
+        volume = {60},
+        number = {12},
+        pages = {6065--6073},
+        author = {John J. Irwin and Khanh G. Tang and Jennifer Young and Chinzorig Dandarchuluun 
+        and Benjamin R. Wong and Munkhzul Khurelbaatar and Yurii S. Moroz and John Mayfield and Roger A. Sayle},
+        title = {{ZINC}20{\textemdash}A Free Ultralarge-Scale Chemical Database for Ligand Discovery},
+        journal = {J. Chem. Inf. Model.}
+      }
+templates:
+  - |- 
+    Task: You are given a {#list|sequence!} of SMILES of {#molecules|chemicals|chemical compounds!} and {#must|are asked to!} find the {#molecule|chemical|compound!} that is {#most|maximally!} different from the others.
+    Molecules: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}
+    Constraint: Answer by returning the SMILES string. Similarity is measured in terms of Tanimoto distance between Morgan fingerprints of radius {#two|2!}.
+    Answer: {odd_one_out_mol#}
+  - |- 
+    Task: You are given a {#list|sequence!} of SMILES of {#molecules|chemicals|chemical compounds!} and {#must|are asked to!} find the pair {#molecule|chemical|compound!} that is {#most|maximally!} different from each other.
+    Molecules: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}
+    Constraint: Answer by returning two SMILES strings separated by a comma. Similarity is measured in terms of Tanimoto distance between Morgan fingerprints of radius {#two|2!}.
+    Answer: {most_diff_0#}, {most_diff_1#}
+  - |- 
+    Task: You are given a {#list|sequence!} of SMILES of {#molecules|chemicals|chemical compounds!} and {#must|are asked to!} find the pair {#molecule|chemical|compound!} that is {#most|maximally!} similar to each other.
+    Molecules: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}
+    Constraint: Answer by returning two SMILES strings separated by a comma. Similarity is measured in terms of Tanimoto distance between Morgan fingerprints of radius {#two|2!}.
+    Answer: {biggest_sim_1#}, {biggest_sim_0#}
+  - |- 
+    Question: I have a {#list|sequence!} of SMILES for {#molecules|chemicals|chemical compounds!}: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}. Which two molecules have the highest similarity based on their Tanimoto distance calculated from Morgan fingerprints of radius {#two|2!}?
+    Answer: The two most similar molecules are {biggest_sim_1#} and {biggest_sim_0#}.
+  - |- 
+    Question: I have the following SMILES strings: {smi_1#}, {smi_2#}, {smi_3#}, and {smi_4#}. Which {#molecule|chemical|chemical compound|compound!} is the most {#dissimilar|different!} from the others based on Tanimoto distance of their Morgan fingerprints of radius {#two|2!}?
+    Answer: The most dissimilar {#molecule|chemical|chemical compound|compound!} is {odd_one_out_mol#}.

--- a/data/tabular/odd_one_out/transform.py
+++ b/data/tabular/odd_one_out/transform.py
@@ -145,6 +145,7 @@ def division_catch_zero(x):
         return np.nan
 
 
+# tune this to tune difficulty of task, not optimized atm
 MAX_SECOND_FIRST_RATIO = 0.5
 MIN_SMALLEST_TO_LARGEST_DIFF = 0.2
 

--- a/data/tabular/odd_one_out/transform.py
+++ b/data/tabular/odd_one_out/transform.py
@@ -1,0 +1,86 @@
+import numpy as np
+from rdkit import Chem
+from rdkit import DataStructs
+from rdkit.Chem import AllChem
+from tdc.generation import MolGen
+from tqdm import tqdm
+
+"""
+Creating the odd-one-out dataset, for an example application such as below:
+
+"Q: Which molecule is the least similar to the others?
+1. [Mol 1]
+2. [Mol 2]
+3. [Mol 3]
+4. [Mol 4]
+
+A: [Answer]"
+
+Uses Tanimoto Similarity with Morgan Fingerprints implemented in RDKit, with radius 2.
+"""
+
+
+def load_dataset():
+    return MolGen(name='ChEMBL_V29').get_split()
+
+
+def transform_dataset(dataset, n_permutations):
+    smis = dataset['smiles'].values
+    # Make sure smi_idx_arr contain no duplicate indexes in any of its rows
+    smi_idx_arr = np.stack([np.arange(len(dataset)) for _ in range(n_permutations)]).T
+    for i in range(n_permutations):
+        smi_idx_arr[:, i] += i
+        smi_idx_arr[:, i] %= len(dataset)
+
+    odd_one_out_idx = []  # the least similar index, or the "odd-one-out"
+
+    for row in tqdm(smi_idx_arr):
+        # gather Morgan fingerprints for all mols in row, with radius of 2
+        fingerprints = []
+        for val in row:
+            mol = Chem.MolFromSmiles(smis[val])
+            fingerprint = AllChem.GetMorganFingerprint(mol, 2)
+            fingerprints.append(fingerprint)
+
+        # Calculate summed Tanimoto similarity of mol i to all remaining mols
+        similarities = []
+        for i in range(len(fingerprints)):
+            similarity_sum = 0
+            for j in range(len(fingerprints)):
+                if i != j:
+                    similarity_sum += DataStructs.TanimotoSimilarity(fingerprints[i], fingerprints[j])
+            similarities.append(similarity_sum)
+
+        lowest_similarity = np.argmin(similarities)
+        odd_one_out_idx.append(lowest_similarity)
+    return smi_idx_arr, odd_one_out_idx
+
+
+def save_dataset_title():
+    with open('data_clean.csv', 'w') as f:
+        col_strs = [f'mol_{i}' for i in range(n_permutations)]
+        f.write(','.join(col_strs) + ',least_similar_index,split\n')  # 'mol_0,mol_1,...,mol_n,least_similar_index,split'
+
+
+def save_dataset(dataset, idx_permutations, odd_one_out_idx, split_label):
+    smis = dataset['smiles'].values
+    with open('data_clean.csv', 'a') as f:
+        for i in tqdm(range(len(smis))):
+            smi_strs = ','.join(smis[idx_permutations[i]])
+            f.write(smi_strs + f',{odd_one_out_idx[i]},{split_label}\n')
+
+
+if __name__ == "__main__":
+    n_permutations = 4  # Controls how many molecules are given in the question
+
+    df = load_dataset()
+    save_dataset_title()
+
+    idx_permutations, odd_one_out_idx = transform_dataset(df['train'], n_permutations)
+    save_dataset(df['train'], idx_permutations, odd_one_out_idx, 'train')
+
+    idx_permutations, odd_one_out_idx = transform_dataset(df['valid'], n_permutations)
+    save_dataset(df['valid'], idx_permutations, odd_one_out_idx, 'valid')
+
+    idx_permutations, odd_one_out_idx = transform_dataset(df['test'], n_permutations)
+    save_dataset(df['test'], idx_permutations, odd_one_out_idx, 'test')

--- a/data/text_sampling/text_sampling.py
+++ b/data/text_sampling/text_sampling.py
@@ -147,7 +147,8 @@ exclude_from_standard_tabular_text_templates = [
     "MUV_852",  # boolean target data
     "MUV_858",  # boolean target data
     "MUV_859",  # boolean target data
-    "orbnet_denali"  # only makes sense for the structure files
+    "orbnet_denali",  # only makes sense for the structure files
+    "odd_one_out"
     # "h2_storage_materials",  # only IUPAC identifier, more than one target, LOW PRIO: has only 30 samples
 ]
 
@@ -997,6 +998,8 @@ if __name__ == "__main__":
 
     for path in path_data_dir:
         # subselect one path
+        # if not "odd_one_out" in path:
+        #     continue
         # if path.find("data/tabular/") == -1: continue
         # if path.find("data/kg/") == -1: continue
         # if path.find("chembl33") != -1: continue


### PR DESCRIPTION
Creating the odd-one-out dataset, for an example application such as below:
"Q: Which molecule is the least similar to the others?

1. [Mol 1]
2. [Mol 2]
3. [Mol 3]
4. [Mol 4]

A: [Answer]"

Uses the ChEMBLv29 dataset (retrieved from therapeutic commons) with Tanimoto Similarity and Morgan Fingerprints implemented in RDKit, with radius 2.